### PR TITLE
move rustcommon dependency to pelikan-io fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 [[package]]
 name = "heatmap"
 version = "0.0.0"
-source = "git+https://github.com/twitter/rustcommon?rev=d550e01#d550e01d3aeb7b334ed44e87652706acb5b3aea8"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
 dependencies = [
  "histogram",
  "rustcommon-time",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "histogram"
 version = "0.0.0"
-source = "git+https://github.com/twitter/rustcommon?rev=d550e01#d550e01d3aeb7b334ed44e87652706acb5b3aea8"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
 dependencies = [
  "thiserror",
 ]
@@ -2032,7 +2032,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 [[package]]
 name = "rustcommon-logger"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?rev=d550e01#d550e01d3aeb7b334ed44e87652706acb5b3aea8"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
 dependencies = [
  "ahash",
  "log",
@@ -2044,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics"
 version = "0.1.2"
-source = "git+https://github.com/twitter/rustcommon?rev=d550e01#d550e01d3aeb7b334ed44e87652706acb5b3aea8"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
 dependencies = [
  "heatmap",
  "linkme",
@@ -2057,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?rev=d550e01#d550e01d3aeb7b334ed44e87652706acb5b3aea8"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-time"
 version = "0.0.13"
-source = "git+https://github.com/twitter/rustcommon?rev=d550e01#d550e01d3aeb7b334ed44e87652706acb5b3aea8"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ quote = "1.0.21"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_xoshiro = "0.6.0"
-rustcommon-logger = { git = "https://github.com/twitter/rustcommon", rev = "d550e01" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", rev = "d550e01" }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon", rev = "d550e01" }
+rustcommon-logger = { git = "https://github.com/pelikan-io/rustcommon", rev = "2d865da" }
+rustcommon-metrics = { git = "https://github.com/pelikan-io/rustcommon", rev = "2d865da" }
+rustcommon-time = { git = "https://github.com/pelikan-io/rustcommon", rev = "2d865da" }
 serde = "1.0.145"
 serde_json = "1.0.85"
 slab = "0.4.7"


### PR DESCRIPTION
Moves the rustcommon dependency from twitter/rustcommon to pelikan-io/rustcommon.