### PR TITLE
bugfix for resp parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "admin"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "common",
  "config",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "bloom"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bitvec",
  "criterion 0.4.0",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "boring",
  "macros",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "common",
  "log",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "datapool"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "blake3",
  "common",
@@ -712,7 +712,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "entrystore"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "common",
  "config",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "common",
  "config",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "momento_proxy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
@@ -1377,7 +1377,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "net"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "boring",
  "boring-sys",
@@ -1631,7 +1631,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pingproxy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
@@ -1645,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "pingserver"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-admin"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "common",
  "config",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes 1.2.1",
  "common",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-http"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arrayvec 0.7.2",
  "assert_matches",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "common",
  "criterion 0.3.6",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "common",
  "config",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-resp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "common",
  "nom 5.1.2",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-thrift"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "common",
  "logger",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "admin",
  "common",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "queues"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "crossbeam-queue",
  "net",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "seg"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "common",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "segcache"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "admin",
  "common",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes 1.2.1",
  "log",
@@ -2351,7 +2351,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-types"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "strsim"
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "thriftproxy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
@@ -2825,7 +2825,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waker"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libc",
  "mio 0.8.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 homepage = "https://pelikan.io"
 repository = "https://github.com/pelikan-io/pelikan"

--- a/src/protocol/resp/src/request/badd.rs
+++ b/src/protocol/resp/src/request/badd.rs
@@ -51,20 +51,41 @@ impl TryFrom<Message> for BAddRequest {
                 return Err(Error::new(ErrorKind::Other, "malformed command"));
             }
 
+            let _command = take_bulk_string(&mut array)?;
+
             let outer_key = take_bulk_string(&mut array)?;
+
+            if outer_key.is_none() {
+                return Err(Error::new(ErrorKind::Other, "malformed command"));
+            }
+
+            let outer_key = outer_key.unwrap();
+
             if outer_key.is_empty() {
                 return Err(Error::new(ErrorKind::Other, "malformed command"));
             }
 
             //loop as long as we have at least 2 arguments after the command
             let mut pairs = Vec::with_capacity(array.len() / 2);
-            while array.len() >= 3 {
+            while array.len() >= 2 {
                 let inner_key = take_bulk_string(&mut array)?;
+                if inner_key.is_none() {
+                    return Err(Error::new(ErrorKind::Other, "malformed command"));
+                }
+                let inner_key = inner_key.unwrap();
+
                 if inner_key.is_empty() {
                     return Err(Error::new(ErrorKind::Other, "malformed command"));
                 }
 
                 let value = take_bulk_string(&mut array)?;
+
+                if value.is_none() {
+                    return Err(Error::new(ErrorKind::Other, "malformed command"));
+                }
+
+                let value = value.unwrap();
+
                 if value.is_empty() {
                     return Err(Error::new(ErrorKind::Other, "malformed command"));
                 }

--- a/src/protocol/resp/src/request/set.rs
+++ b/src/protocol/resp/src/request/set.rs
@@ -76,8 +76,6 @@ impl TryFrom<Message> for SetRequest {
             let mut mode = SetMode::Set;
             let mut get_old = false;
 
-            // let mut i = 1;
-
             while let Some(token) = take_bulk_string_as_utf8(&mut array)? {
                 match token.as_str() {
                     "EX" => {


### PR DESCRIPTION
Fixes #3 by improving the utlity functions which we use to operate
on the array of tokens.

Previously, we were having to track our position in the token
stream but were mixing that with functions which removed tokens
from the stream.

This change makes all the utility functions act by attempting to
take a token from the front of the token stream. This makes the
parser more intuitive to write and less likely to have the same
class of bug.