### PR TITLE
use clocksource from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "clocksource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90cc4cec392a6d97223f008b5da7a3c2c71aa6d5ffdf0e3e14d8b2432738387"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "mach",
+ "time 0.3.14",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "clocksource"
+version = "0.6.0"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=767b4e9#767b4e9289c7a3f732b344b5faf11397733416bb"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "mach",
+ "time 0.3.14",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,11 +535,11 @@ name = "common"
 version = "0.3.1"
 dependencies = [
  "boring",
+ "clocksource 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "macros",
  "net",
  "rustcommon-logger",
  "rustcommon-metrics",
- "rustcommon-time",
  "serde",
 ]
 
@@ -933,11 +958,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heatmap"
-version = "0.0.0"
-source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a040d43defb8644617d52575557275232693a27c594d136b16c12283244683"
 dependencies = [
+ "clocksource 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "histogram",
- "rustcommon-time",
  "thiserror",
 ]
 
@@ -958,8 +984,9 @@ dependencies = [
 
 [[package]]
 name = "histogram"
-version = "0.0.0"
-source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913e066ae237bc8adb23b539f140ae81152af2dc3ff357ada35af13bcf48f016"
 dependencies = [
  "thiserror",
 ]
@@ -2091,49 +2118,37 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 [[package]]
 name = "rustcommon-logger"
 version = "0.1.1"
-source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=767b4e9#767b4e9289c7a3f732b344b5faf11397733416bb"
 dependencies = [
  "ahash",
+ "clocksource 0.6.0 (git+https://github.com/pelikan-io/rustcommon?rev=767b4e9)",
  "log",
  "mpmc",
  "rustcommon-metrics",
- "rustcommon-time",
 ]
 
 [[package]]
 name = "rustcommon-metrics"
 version = "0.1.2"
-source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=767b4e9#767b4e9289c7a3f732b344b5faf11397733416bb"
 dependencies = [
+ "clocksource 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heatmap",
  "linkme",
  "once_cell",
  "parking_lot",
  "rustcommon-metrics-derive",
- "rustcommon-time",
 ]
 
 [[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.1"
-source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
+source = "git+https://github.com/pelikan-io/rustcommon?rev=767b4e9#767b4e9289c7a3f732b344b5faf11397733416bb"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "rustcommon-time"
-version = "0.0.13"
-source = "git+https://github.com/pelikan-io/rustcommon?rev=2d865da#2d865da861e3b845137f6002614de0728a0404f3"
-dependencies = [
- "lazy_static",
- "libc",
- "mach",
- "time 0.3.14",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2333,11 +2348,11 @@ name = "session"
 version = "0.3.1"
 dependencies = [
  "bytes 1.2.1",
+ "common",
  "log",
  "net",
  "protocol-common",
  "rustcommon-metrics",
- "rustcommon-time",
 ]
 
 [[package]]
@@ -2486,18 +2501,18 @@ checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ boring-sys = "2.1.0"
 bstr = "1.0.1"
 bytes = "1.2.1"
 clap = "2.33.3"
+clocksource = "0.6.0"
 crossbeam-channel = "0.5.6"
 crossbeam-queue = "0.3.5"
 foreign-types-shared = "0.3.1"
@@ -64,9 +65,8 @@ quote = "1.0.21"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_xoshiro = "0.6.0"
-rustcommon-logger = { git = "https://github.com/pelikan-io/rustcommon", rev = "2d865da" }
-rustcommon-metrics = { git = "https://github.com/pelikan-io/rustcommon", rev = "2d865da" }
-rustcommon-time = { git = "https://github.com/pelikan-io/rustcommon", rev = "2d865da" }
+rustcommon-logger = { git = "https://github.com/pelikan-io/rustcommon", rev = "767b4e9" }
+rustcommon-metrics = { git = "https://github.com/pelikan-io/rustcommon", rev = "767b4e9" }
 serde = "1.0.145"
 serde_json = "1.0.85"
 slab = "0.4.7"

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -11,9 +11,9 @@ license = { workspace = true }
 
 [dependencies]
 boring = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-net = { path = "../net" }
+clocksource = { workspace = true }
 macros = { path = "../macros" }
+net = { path = "../net" }
 rustcommon-metrics = { workspace = true }
 rustcommon-logger = { workspace = true }
-rustcommon-time = { workspace = true }
+serde = { workspace = true, features = ["derive"] }

--- a/src/common/src/time.rs
+++ b/src/common/src/time.rs
@@ -1,3 +1,3 @@
-pub use rustcommon_time::{
+pub use clocksource::{
     refresh_clock, DateTime, Duration, Instant, Nanoseconds, Seconds, SecondsFormat, UnixInstant,
 };

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -10,8 +10,8 @@ license = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }
+common = { path = "../common" }
 log = { workspace = true }
 net = { path = "../net" }
 protocol-common = { path = "../protocol/common" }
 rustcommon-metrics = { workspace = true }
-rustcommon-time = { workspace = true }

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -29,7 +29,7 @@ use core::marker::PhantomData;
 use protocol_common::Compose;
 use protocol_common::Parse;
 use rustcommon_metrics::*;
-use rustcommon_time::Nanoseconds;
+use common::time::Nanoseconds;
 use std::collections::VecDeque;
 use std::io::Error;
 use std::io::ErrorKind;
@@ -63,7 +63,7 @@ heatmap!(
     "distribution of request latencies in nanoseconds"
 );
 
-type Instant = rustcommon_time::Instant<Nanoseconds<u64>>;
+type Instant = common::time::Instant<Nanoseconds<u64>>;
 
 // The size of one kilobyte, in bytes
 const KB: usize = 1024;


### PR DESCRIPTION
Moves the rustcommon-time dependency to clocksource which is now published on crates.io

Updates rustcommon to latest version