### PR TITLE
refactor resp protocol

### DIFF
--- a/src/protocol/resp/src/request/get.rs
+++ b/src/protocol/resp/src/request/get.rs
@@ -7,11 +7,11 @@ use std::io::{Error, ErrorKind};
 use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct GetRequest {
+pub struct Get {
     key: Arc<[u8]>,
 }
 
-impl TryFrom<Message> for GetRequest {
+impl TryFrom<Message> for Get {
     type Error = Error;
 
     fn try_from(other: Message) -> Result<Self, Error> {
@@ -49,7 +49,7 @@ impl TryFrom<Message> for GetRequest {
     }
 }
 
-impl GetRequest {
+impl Get {
     pub fn new(key: &[u8]) -> Self {
         Self { key: key.into() }
     }
@@ -59,8 +59,8 @@ impl GetRequest {
     }
 }
 
-impl From<&GetRequest> for Message {
-    fn from(other: &GetRequest) -> Message {
+impl From<&Get> for Message {
+    fn from(other: &Get) -> Message {
         Message::Array(Array {
             inner: Some(vec![
                 Message::BulkString(BulkString::new(b"GET")),
@@ -70,7 +70,7 @@ impl From<&GetRequest> for Message {
     }
 }
 
-impl Compose for GetRequest {
+impl Compose for Get {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         let message = Message::from(self);
         message.compose(buf)
@@ -86,7 +86,7 @@ mod tests {
         let parser = RequestParser::new();
         assert_eq!(
             parser.parse(b"get 0\r\n").unwrap().into_inner(),
-            Request::Get(GetRequest::new(b"0"))
+            Request::Get(Get::new(b"0"))
         );
 
         assert_eq!(
@@ -94,7 +94,7 @@ mod tests {
                 .parse(b"get \"\0\r\n key\"\r\n")
                 .unwrap()
                 .into_inner(),
-            Request::Get(GetRequest::new(b"\0\r\n key"))
+            Request::Get(Get::new(b"\0\r\n key"))
         );
 
         assert_eq!(
@@ -102,7 +102,7 @@ mod tests {
                 .parse(b"*2\r\n$3\r\nget\r\n$1\r\n0\r\n")
                 .unwrap()
                 .into_inner(),
-            Request::Get(GetRequest::new(b"0"))
+            Request::Get(Get::new(b"0"))
         );
     }
 }

--- a/src/protocol/resp/src/request/hexists.rs
+++ b/src/protocol/resp/src/request/hexists.rs
@@ -11,12 +11,12 @@ counter!(HEXISTS_HIT);
 counter!(HEXISTS_MISS);
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HashExistsRequest {
+pub struct HashExists {
     key: Arc<[u8]>,
     field: Arc<[u8]>,
 }
 
-impl TryFrom<Message> for HashExistsRequest {
+impl TryFrom<Message> for HashExists {
     type Error = Error;
 
     fn try_from(other: Message) -> Result<Self, Error> {
@@ -54,7 +54,7 @@ impl TryFrom<Message> for HashExistsRequest {
     }
 }
 
-impl HashExistsRequest {
+impl HashExists {
     pub fn new(key: &[u8], field: &[u8]) -> Self {
         Self {
             key: key.into(),
@@ -71,8 +71,8 @@ impl HashExistsRequest {
     }
 }
 
-impl From<&HashExistsRequest> for Message {
-    fn from(other: &HashExistsRequest) -> Message {
+impl From<&HashExists> for Message {
+    fn from(other: &HashExists) -> Message {
         Message::Array(Array {
             inner: Some(vec![
                 Message::BulkString(BulkString::new(b"HEXISTS")),
@@ -83,7 +83,7 @@ impl From<&HashExistsRequest> for Message {
     }
 }
 
-impl Compose for HashExistsRequest {
+impl Compose for HashExists {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         let message = Message::from(self);
         message.compose(buf)
@@ -99,7 +99,7 @@ mod tests {
         let parser = RequestParser::new();
         assert_eq!(
             parser.parse(b"hexists 0 1\r\n").unwrap().into_inner(),
-            Request::HashExists(HashExistsRequest::new(b"0", b"1"))
+            Request::HashExists(HashExists::new(b"0", b"1"))
         );
 
         assert_eq!(
@@ -107,7 +107,7 @@ mod tests {
                 .parse(b"*3\r\n$7\r\nhexists\r\n$1\r\n0\r\n$1\r\n1\r\n")
                 .unwrap()
                 .into_inner(),
-            Request::HashExists(HashExistsRequest::new(b"0", b"1"))
+            Request::HashExists(HashExists::new(b"0", b"1"))
         );
     }
 }

--- a/src/protocol/resp/src/request/hget.rs
+++ b/src/protocol/resp/src/request/hget.rs
@@ -11,12 +11,12 @@ counter!(HGET_HIT);
 counter!(HGET_MISS);
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HashGetRequest {
+pub struct HashGet {
     key: Arc<[u8]>,
     field: Arc<[u8]>,
 }
 
-impl TryFrom<Message> for HashGetRequest {
+impl TryFrom<Message> for HashGet {
     type Error = Error;
 
     fn try_from(other: Message) -> Result<Self, Error> {
@@ -54,7 +54,7 @@ impl TryFrom<Message> for HashGetRequest {
     }
 }
 
-impl HashGetRequest {
+impl HashGet {
     pub fn new(key: &[u8], field: &[u8]) -> Self {
         Self {
             key: key.into(),
@@ -71,8 +71,8 @@ impl HashGetRequest {
     }
 }
 
-impl From<&HashGetRequest> for Message {
-    fn from(other: &HashGetRequest) -> Message {
+impl From<&HashGet> for Message {
+    fn from(other: &HashGet) -> Message {
         Message::Array(Array {
             inner: Some(vec![
                 Message::BulkString(BulkString::new(b"HGET")),
@@ -83,7 +83,7 @@ impl From<&HashGetRequest> for Message {
     }
 }
 
-impl Compose for HashGetRequest {
+impl Compose for HashGet {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         let message = Message::from(self);
         message.compose(buf)
@@ -99,7 +99,7 @@ mod tests {
         let parser = RequestParser::new();
         assert_eq!(
             parser.parse(b"hget 0 1\r\n").unwrap().into_inner(),
-            Request::HashGet(HashGetRequest::new(b"0", b"1"))
+            Request::HashGet(HashGet::new(b"0", b"1"))
         );
 
         assert_eq!(
@@ -107,7 +107,7 @@ mod tests {
                 .parse(b"*3\r\n$4\r\nhget\r\n$1\r\n0\r\n$1\r\n1\r\n")
                 .unwrap()
                 .into_inner(),
-            Request::HashGet(HashGetRequest::new(b"0", b"1"))
+            Request::HashGet(HashGet::new(b"0", b"1"))
         );
     }
 }

--- a/src/protocol/resp/src/request/hgetall.rs
+++ b/src/protocol/resp/src/request/hgetall.rs
@@ -12,11 +12,11 @@ counter!(HGETALL_HIT);
 counter!(HGETALL_MISS);
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HashGetAllRequest {
+pub struct HashGetAll {
     key: Arc<[u8]>,
 }
 
-impl TryFrom<Message> for HashGetAllRequest {
+impl TryFrom<Message> for HashGetAll {
     type Error = Error;
 
     fn try_from(other: Message) -> Result<Self, Error> {
@@ -47,7 +47,7 @@ impl TryFrom<Message> for HashGetAllRequest {
     }
 }
 
-impl HashGetAllRequest {
+impl HashGetAll {
     pub fn new(key: &[u8]) -> Self {
         Self { key: key.into() }
     }
@@ -57,8 +57,8 @@ impl HashGetAllRequest {
     }
 }
 
-impl From<&HashGetAllRequest> for Message {
-    fn from(other: &HashGetAllRequest) -> Message {
+impl From<&HashGetAll> for Message {
+    fn from(other: &HashGetAll) -> Message {
         Message::Array(Array {
             inner: Some(vec![
                 Message::BulkString(BulkString::new(b"HGETALL")),
@@ -68,7 +68,7 @@ impl From<&HashGetAllRequest> for Message {
     }
 }
 
-impl Compose for HashGetAllRequest {
+impl Compose for HashGetAll {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         let message = Message::from(self);
         message.compose(buf)
@@ -84,7 +84,7 @@ mod tests {
         let parser = RequestParser::new();
         assert_eq!(
             parser.parse(b"hgetall 0\r\n").unwrap().into_inner(),
-            Request::HashGetAll(HashGetAllRequest::new(b"0"))
+            Request::HashGetAll(HashGetAll::new(b"0"))
         );
 
         assert_eq!(
@@ -92,7 +92,7 @@ mod tests {
                 .parse(b"*2\r\n$7\r\nhgetall\r\n$1\r\n0\r\n")
                 .unwrap()
                 .into_inner(),
-            Request::HashGetAll(HashGetAllRequest::new(b"0"))
+            Request::HashGetAll(HashGetAll::new(b"0"))
         );
     }
 }

--- a/src/protocol/resp/src/request/hkeys.rs
+++ b/src/protocol/resp/src/request/hkeys.rs
@@ -12,11 +12,11 @@ counter!(HKEYS_HIT);
 counter!(HKEYS_MISS);
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HashKeysRequest {
+pub struct HashKeys {
     key: Arc<[u8]>,
 }
 
-impl TryFrom<Message> for HashKeysRequest {
+impl TryFrom<Message> for HashKeys {
     type Error = Error;
 
     fn try_from(other: Message) -> Result<Self, Error> {
@@ -47,7 +47,7 @@ impl TryFrom<Message> for HashKeysRequest {
     }
 }
 
-impl HashKeysRequest {
+impl HashKeys {
     pub fn new(key: &[u8]) -> Self {
         Self { key: key.into() }
     }
@@ -57,8 +57,8 @@ impl HashKeysRequest {
     }
 }
 
-impl From<&HashKeysRequest> for Message {
-    fn from(other: &HashKeysRequest) -> Message {
+impl From<&HashKeys> for Message {
+    fn from(other: &HashKeys) -> Message {
         Message::Array(Array {
             inner: Some(vec![
                 Message::BulkString(BulkString::new(b"HKEYS")),
@@ -68,7 +68,7 @@ impl From<&HashKeysRequest> for Message {
     }
 }
 
-impl Compose for HashKeysRequest {
+impl Compose for HashKeys {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         let message = Message::from(self);
         message.compose(buf)
@@ -84,7 +84,7 @@ mod tests {
         let parser = RequestParser::new();
         assert_eq!(
             parser.parse(b"hkeys 0\r\n").unwrap().into_inner(),
-            Request::HashKeys(HashKeysRequest::new(b"0"))
+            Request::HashKeys(HashKeys::new(b"0"))
         );
 
         assert_eq!(
@@ -92,7 +92,7 @@ mod tests {
                 .parse(b"*2\r\n$5\r\nhkeys\r\n$1\r\n0\r\n")
                 .unwrap()
                 .into_inner(),
-            Request::HashKeys(HashKeysRequest::new(b"0"))
+            Request::HashKeys(HashKeys::new(b"0"))
         );
     }
 }

--- a/src/protocol/resp/src/request/hlen.rs
+++ b/src/protocol/resp/src/request/hlen.rs
@@ -11,11 +11,11 @@ counter!(HLEN_HIT);
 counter!(HLEN_MISS);
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HashLengthRequest {
+pub struct HashLength {
     key: Arc<[u8]>,
 }
 
-impl TryFrom<Message> for HashLengthRequest {
+impl TryFrom<Message> for HashLength {
     type Error = Error;
 
     fn try_from(other: Message) -> Result<Self, Error> {
@@ -46,7 +46,7 @@ impl TryFrom<Message> for HashLengthRequest {
     }
 }
 
-impl HashLengthRequest {
+impl HashLength {
     pub fn new(key: &[u8]) -> Self {
         Self { key: key.into() }
     }
@@ -56,8 +56,8 @@ impl HashLengthRequest {
     }
 }
 
-impl From<&HashLengthRequest> for Message {
-    fn from(other: &HashLengthRequest) -> Message {
+impl From<&HashLength> for Message {
+    fn from(other: &HashLength) -> Message {
         Message::Array(Array {
             inner: Some(vec![
                 Message::BulkString(BulkString::new(b"HLEN")),
@@ -67,7 +67,7 @@ impl From<&HashLengthRequest> for Message {
     }
 }
 
-impl Compose for HashLengthRequest {
+impl Compose for HashLength {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         let message = Message::from(self);
         message.compose(buf)
@@ -83,7 +83,7 @@ mod tests {
         let parser = RequestParser::new();
         assert_eq!(
             parser.parse(b"hlen 0\r\n").unwrap().into_inner(),
-            Request::HashLength(HashLengthRequest::new(b"0"))
+            Request::HashLength(HashLength::new(b"0"))
         );
 
         assert_eq!(
@@ -91,7 +91,7 @@ mod tests {
                 .parse(b"*2\r\n$4\r\nhlen\r\n$1\r\n0\r\n")
                 .unwrap()
                 .into_inner(),
-            Request::HashLength(HashLengthRequest::new(b"0"))
+            Request::HashLength(HashLength::new(b"0"))
         );
     }
 }

--- a/src/protocol/resp/src/request/hmget.rs
+++ b/src/protocol/resp/src/request/hmget.rs
@@ -13,12 +13,12 @@ counter!(HMGET_FIELD_HIT);
 counter!(HMGET_FIELD_MISS);
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HashMultiGetRequest {
+pub struct HashMultiGet {
     key: Arc<[u8]>,
     fields: Box<[Arc<[u8]>]>,
 }
 
-impl TryFrom<Message> for HashMultiGetRequest {
+impl TryFrom<Message> for HashMultiGet {
     type Error = Error;
 
     fn try_from(other: Message) -> Result<Self, Error> {
@@ -61,7 +61,7 @@ impl TryFrom<Message> for HashMultiGetRequest {
     }
 }
 
-impl HashMultiGetRequest {
+impl HashMultiGet {
     pub fn new(key: &[u8], fields: &[&[u8]]) -> Self {
         let fields: Vec<Arc<[u8]>> = fields.iter().map(|f| (*f).into()).collect();
 
@@ -80,8 +80,8 @@ impl HashMultiGetRequest {
     }
 }
 
-impl From<&HashMultiGetRequest> for Message {
-    fn from(other: &HashMultiGetRequest) -> Message {
+impl From<&HashMultiGet> for Message {
+    fn from(other: &HashMultiGet) -> Message {
         let mut data = vec![
             Message::BulkString(BulkString::new(b"HMGET")),
             Message::BulkString(BulkString::from(other.key.clone())),
@@ -95,7 +95,7 @@ impl From<&HashMultiGetRequest> for Message {
     }
 }
 
-impl Compose for HashMultiGetRequest {
+impl Compose for HashMultiGet {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         let message = Message::from(self);
         message.compose(buf)
@@ -111,7 +111,7 @@ mod tests {
         let parser = RequestParser::new();
         assert_eq!(
             parser.parse(b"hmget 0 1 2\r\n").unwrap().into_inner(),
-            Request::HashMultiGet(HashMultiGetRequest::new(b"0", &[b"1", b"2"]))
+            Request::HashMultiGet(HashMultiGet::new(b"0", &[b"1", b"2"]))
         );
 
         assert_eq!(
@@ -119,7 +119,7 @@ mod tests {
                 .parse(b"*4\r\n$5\r\nhmget\r\n$1\r\n0\r\n$1\r\n1\r\n$1\r\n2\r\n")
                 .unwrap()
                 .into_inner(),
-            Request::HashMultiGet(HashMultiGetRequest::new(b"0", &[b"1", b"2"]))
+            Request::HashMultiGet(HashMultiGet::new(b"0", &[b"1", b"2"]))
         );
     }
 }

--- a/src/protocol/resp/src/request/hvals.rs
+++ b/src/protocol/resp/src/request/hvals.rs
@@ -11,11 +11,11 @@ counter!(HVALS_HIT);
 counter!(HVALS_MISS);
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HashValuesRequest {
+pub struct HashValues {
     key: Arc<[u8]>,
 }
 
-impl TryFrom<Message> for HashValuesRequest {
+impl TryFrom<Message> for HashValues {
     type Error = Error;
 
     fn try_from(other: Message) -> Result<Self, Error> {
@@ -46,7 +46,7 @@ impl TryFrom<Message> for HashValuesRequest {
     }
 }
 
-impl HashValuesRequest {
+impl HashValues {
     pub fn new(key: &[u8]) -> Self {
         Self { key: key.into() }
     }
@@ -56,8 +56,8 @@ impl HashValuesRequest {
     }
 }
 
-impl From<&HashValuesRequest> for Message {
-    fn from(other: &HashValuesRequest) -> Message {
+impl From<&HashValues> for Message {
+    fn from(other: &HashValues) -> Message {
         Message::Array(Array {
             inner: Some(vec![
                 Message::BulkString(BulkString::new(b"HVALS")),
@@ -67,7 +67,7 @@ impl From<&HashValuesRequest> for Message {
     }
 }
 
-impl Compose for HashValuesRequest {
+impl Compose for HashValues {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         let message = Message::from(self);
         message.compose(buf)
@@ -83,7 +83,7 @@ mod tests {
         let parser = RequestParser::new();
         assert_eq!(
             parser.parse(b"hvals 0\r\n").unwrap().into_inner(),
-            Request::HashValues(HashValuesRequest::new(b"0"))
+            Request::HashValues(HashValues::new(b"0"))
         );
 
         assert_eq!(
@@ -91,7 +91,7 @@ mod tests {
                 .parse(b"*2\r\n$5\r\nhvals\r\n$1\r\n0\r\n")
                 .unwrap()
                 .into_inner(),
-            Request::HashValues(HashValuesRequest::new(b"0"))
+            Request::HashValues(HashValues::new(b"0"))
         );
     }
 }

--- a/src/protocol/resp/src/request/set.rs
+++ b/src/protocol/resp/src/request/set.rs
@@ -14,7 +14,7 @@ pub enum SetMode {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SetRequest {
+pub struct Set {
     key: Arc<[u8]>,
     value: Arc<[u8]>,
     expire_time: Option<ExpireTime>,
@@ -22,7 +22,23 @@ pub struct SetRequest {
     get_old: bool,
 }
 
-impl SetRequest {
+impl Set {
+    pub fn new(
+        key: &[u8],
+        value: &[u8],
+        expire_time: Option<ExpireTime>,
+        mode: SetMode,
+        get_old: bool,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+            expire_time,
+            mode,
+            get_old,
+        }
+    }
+
     pub fn key(&self) -> &[u8] {
         &self.key
     }
@@ -44,7 +60,7 @@ impl SetRequest {
     }
 }
 
-impl TryFrom<Message> for SetRequest {
+impl TryFrom<Message> for Set {
     type Error = Error;
 
     fn try_from(other: Message) -> Result<Self, Error> {
@@ -163,8 +179,8 @@ impl TryFrom<Message> for SetRequest {
     }
 }
 
-impl From<&SetRequest> for Message {
-    fn from(other: &SetRequest) -> Message {
+impl From<&Set> for Message {
+    fn from(other: &Set) -> Message {
         let mut v = vec![
             Message::bulk_string(b"SET"),
             Message::BulkString(BulkString::from(other.key.clone())),
@@ -212,7 +228,7 @@ impl From<&SetRequest> for Message {
     }
 }
 
-impl Compose for SetRequest {
+impl Compose for Set {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         let message = Message::from(self);
         message.compose(buf)

--- a/src/proxy/momento/src/protocol/resp/set.rs
+++ b/src/proxy/momento/src/protocol/resp/set.rs
@@ -6,13 +6,13 @@ use crate::klog::klog_set;
 use crate::{Error, *};
 use ::net::*;
 use protocol_memcache::*;
-use protocol_resp::SetRequest;
+use protocol_resp::Set;
 
 pub async fn set(
     client: &mut SimpleCacheClient,
     cache_name: &str,
     socket: &mut tokio::net::TcpStream,
-    request: &SetRequest,
+    request: &Set,
 ) -> Result<(), Error> {
     SET.increment();
 


### PR DESCRIPTION
Minor refactoring of the RESP protocol to make struct names more consistent with memcache protocol implementation.

Adds constructor methods for request types to make it usable from client code.