### PR TITLE
chore: Update momento to v0.21.0

### DIFF
--- a/.github/actions/setup-protoc/action.yml
+++ b/.github/actions/setup-protoc/action.yml
@@ -1,0 +1,23 @@
+name: setup-protoc
+description: Install the protoc compiler
+runs:
+  using: composite
+  steps:
+    - name: Debug Info
+      run: |
+        case $RUNNER_OS in
+          Linux)
+            sudo apt-get install -y protobuf-compiler
+            ;;
+          macOS)
+            brew install protobuf
+            ;;
+          *)
+            echo "setup-protoc does not support $RUNNER_OS!"
+            exit 1
+            ;;
+        esac
+
+        echo Running on $RUNNER_OS
+        protoc --version
+      shell: bash

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -18,7 +18,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          # Github ratelimits some API requests that this action does. However,
+          # if requests are authenticated then they get a higher rate limit. So
+          # we use the default actions token to authenticate here.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup rustc toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
@@ -59,7 +67,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          # Github ratelimits some API requests that this action does. However,
+          # if requests are authenticated then they get a higher rate limit. So
+          # we use the default actions token to authenticate here.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup rustc toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
@@ -90,9 +106,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          # Github ratelimits some API requests that this action does. However,
+          # if requests are authenticated then they get a higher rate limit. So
+          # we use the default actions token to authenticate here.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup rustc toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
@@ -122,6 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: arduino/setup-protoc@v1
       - uses: Swatinem/rust-cache@v1
         with:
           key: clippy
@@ -146,14 +172,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          # Github ratelimits some API requests that this action does. However,
+          # if requests are authenticated then they get a higher rate limit. So
+          # we use the default actions token to authenticate here.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup rustc toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Build Cache for Pelikan
         uses: Swatinem/rust-cache@v1
         with:
           key: pelikan
           working-directory: pelikan
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - uses: ./pelikan/.github/actions/ca
       - uses: ./pelikan/.github/actions/pingserver
         with:
@@ -171,6 +205,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          # Github ratelimits some API requests that this action does. However,
+          # if requests are authenticated then they get a higher rate limit. So
+          # we use the default actions token to authenticate here.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup rustc toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Build Cache for Pelikan
         uses: Swatinem/rust-cache@v1
         with:
@@ -196,14 +241,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          # Github ratelimits some API requests that this action does. However,
+          # if requests are authenticated then they get a higher rate limit. So
+          # we use the default actions token to authenticate here.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup rustc toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Build Cache for Pelikan
         uses: Swatinem/rust-cache@v1
         with:
           key: pelikan
           working-directory: pelikan
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - uses: ./pelikan/.github/actions/ca
       - uses: ./pelikan/.github/actions/pingserver
         with:
@@ -224,14 +277,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          # Github ratelimits some API requests that this action does. However,
+          # if requests are authenticated then they get a higher rate limit. So
+          # we use the default actions token to authenticate here.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup rustc toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Build Cache for Pelikan
         uses: Swatinem/rust-cache@v1
         with:
           key: pelikan
           working-directory: pelikan
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - uses: ./pelikan/.github/actions/ca
       - uses: ./pelikan/.github/actions/pingserver
         with:
@@ -252,14 +313,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          # Github ratelimits some API requests that this action does. However,
+          # if requests are authenticated then they get a higher rate limit. So
+          # we use the default actions token to authenticate here.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup rustc toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Build Cache for Pelikan
         uses: Swatinem/rust-cache@v1
         with:
           key: pelikan
           working-directory: pelikan
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - uses: ./pelikan/.github/actions/pingserver
         with:
           tls: false   

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -18,13 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # Github ratelimits some API requests that this action does. However,
-          # if requests are authenticated then they get a higher rate limit. So
-          # we use the default actions token to authenticate here.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-protoc
       - name: Setup rustc toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -67,15 +61,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # Github ratelimits some API requests that this action does. However,
-          # if requests are authenticated then they get a higher rate limit. So
-          # we use the default actions token to authenticate here.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup rustc toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: ./.github/actions/setup-protoc
+      - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
@@ -106,18 +93,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # Github ratelimits some API requests that this action does. However,
-          # if requests are authenticated then they get a higher rate limit. So
-          # we use the default actions token to authenticate here.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup rustc toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: ./.github/actions/setup-protoc
+      - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
@@ -147,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: arduino/setup-protoc@v1
+      - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v1
         with:
           key: clippy
@@ -172,15 +151,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # Github ratelimits some API requests that this action does. However,
-          # if requests are authenticated then they get a higher rate limit. So
-          # we use the default actions token to authenticate here.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup rustc toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: ./pelikan/.github/actions/setup-protoc
+      - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
       - name: Build Cache for Pelikan
@@ -188,6 +160,9 @@ jobs:
         with:
           key: pelikan
           working-directory: pelikan
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - uses: ./pelikan/.github/actions/ca
       - uses: ./pelikan/.github/actions/pingserver
         with:
@@ -205,17 +180,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # Github ratelimits some API requests that this action does. However,
-          # if requests are authenticated then they get a higher rate limit. So
-          # we use the default actions token to authenticate here.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup rustc toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: ./pelikan/.github/actions/setup-protoc
       - name: Build Cache for Pelikan
         uses: Swatinem/rust-cache@v1
         with:
@@ -241,22 +206,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # Github ratelimits some API requests that this action does. However,
-          # if requests are authenticated then they get a higher rate limit. So
-          # we use the default actions token to authenticate here.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup rustc toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: ./pelikan/.github/actions/setup-protoc
       - name: Build Cache for Pelikan
         uses: Swatinem/rust-cache@v1
         with:
           key: pelikan
           working-directory: pelikan
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - uses: ./pelikan/.github/actions/ca
       - uses: ./pelikan/.github/actions/pingserver
         with:
@@ -277,22 +235,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # Github ratelimits some API requests that this action does. However,
-          # if requests are authenticated then they get a higher rate limit. So
-          # we use the default actions token to authenticate here.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup rustc toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: ./pelikan/.github/actions/setup-protoc
       - name: Build Cache for Pelikan
         uses: Swatinem/rust-cache@v1
         with:
           key: pelikan
           working-directory: pelikan
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - uses: ./pelikan/.github/actions/ca
       - uses: ./pelikan/.github/actions/pingserver
         with:
@@ -313,22 +264,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: pelikan
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # Github ratelimits some API requests that this action does. However,
-          # if requests are authenticated then they get a higher rate limit. So
-          # we use the default actions token to authenticate here.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup rustc toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: ./pelikan/.github/actions/setup-protoc
       - name: Build Cache for Pelikan
         uses: Swatinem/rust-cache@v1
         with:
           key: pelikan
           working-directory: pelikan
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - uses: ./pelikan/.github/actions/pingserver
         with:
           tls: false   

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -29,13 +29,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          # Github ratelimits some API requests that this action does. However,
-          # if requests are authenticated then they get a higher rate limit. So
-          # we use the default actions token to authenticate here.
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup-protoc
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{ matrix.os }}-${{ matrix.target }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -29,6 +29,13 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          # Github ratelimits some API requests that this action does. However,
+          # if requests are authenticated then they get a higher rate limit. So
+          # we use the default actions token to authenticate here.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{ matrix.os }}-${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "e5694b64066a2459918d8074c2ce0d5a88f409431994c2356617c8ae0c4721fc"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -173,9 +173,9 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-layer",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
 dependencies = [
  "async-trait",
  "bytes 1.3.0",
@@ -194,6 +194,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -1307,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -1445,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41701538a4ccfcce8aee2a90172190f7d10293f3f27f678b56fd0d380cfb2b89"
+checksum = "711e204d396c31110ceb6c90bc0ebfa0317b27fd7c8a8d03f35ac79e8e07b7b8"
 dependencies = [
  "chrono",
  "jsonwebtoken",
@@ -1456,14 +1457,15 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "thiserror",
  "tonic",
 ]
 
 [[package]]
 name = "momento-protos"
-version = "0.37.0"
+version = "0.42.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d077d0f511db79cd74533ae314eb1e7b1472cfe2530b0ba0638b41682f7a43"
+checksum = "96090893dc2e29b8cd9d2dd1f740e6d44b4885d1739c61ea61ca12da23811da0"
 dependencies = [
  "prost",
  "tonic",
@@ -1851,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes 1.3.0",
  "prost-derive",
@@ -1861,31 +1863,31 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
+checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
 dependencies = [
  "bytes 1.3.0",
- "cfg-if 1.0.0",
- "cmake",
  "heck",
  "itertools",
  "lazy_static",
  "log",
  "multimap",
  "petgraph",
+ "prettyplease",
  "prost",
  "prost-types",
  "regex",
+ "syn",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.10.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1896,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
  "bytes 1.3.0",
  "prost",
@@ -2212,6 +2214,12 @@ checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
@@ -2764,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.7.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2800,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.7.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2852,9 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"

--- a/src/config/src/momento_proxy.rs
+++ b/src/config/src/momento_proxy.rs
@@ -2,6 +2,7 @@ use crate::{Admin, AdminConfig, Debug, DebugConfig, Klog, KlogConfig};
 use core::num::NonZeroU64;
 use std::net::AddrParseError;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -75,8 +76,8 @@ impl Cache {
     }
 
     /// The default TTL (in seconds) for
-    pub fn default_ttl(&self) -> NonZeroU64 {
-        self.default_ttl
+    pub fn default_ttl(&self) -> Duration {
+        Duration::from_secs(self.default_ttl.get())
     }
 
     pub fn protocol(&self) -> Protocol {

--- a/src/proxy/momento/Cargo.toml
+++ b/src/proxy/momento/Cargo.toml
@@ -17,7 +17,7 @@ config = { path = "../../config" }
 libc = { workspace = true }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-momento = "0.17.0"
+momento = "0.21.0"
 net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-memcache = { path = "../../protocol/memcache" }

--- a/src/proxy/momento/src/protocol/memcache/set.rs
+++ b/src/proxy/momento/src/protocol/memcache/set.rs
@@ -27,15 +27,10 @@ pub async fn set(
 
     BACKEND_REQUEST.increment();
 
-    let ttl = if let Some(ttl) = request.ttl().get() {
-        if ttl < 0 {
-            NonZeroU64::new(1)
-        } else {
-            NonZeroU64::new(ttl as u64)
-        }
-    } else {
-        None
-    };
+    let ttl = request
+        .ttl()
+        .get()
+        .map(|ttl| Duration::from_millis(ttl.max(1) as u64));
 
     match timeout(
         Duration::from_millis(200),

--- a/src/proxy/momento/src/protocol/resp/hincrby.rs
+++ b/src/proxy/momento/src/protocol/resp/hincrby.rs
@@ -5,7 +5,7 @@
 use std::io::Write;
 use std::time::Duration;
 
-use momento::simple_cache_client::SimpleCacheClient;
+use momento::SimpleCacheClient;
 use net::TCP_SEND_BYTE;
 use protocol_resp::*;
 use session::{SESSION_SEND, SESSION_SEND_BYTE, SESSION_SEND_EX};
@@ -14,7 +14,7 @@ use tokio::net::TcpStream;
 use tokio::time::timeout;
 
 use crate::klog::{klog_1, Status};
-use crate::{BACKEND_EX, BACKEND_EX_TIMEOUT, BACKEND_REQUEST};
+use crate::{BACKEND_EX, BACKEND_EX_TIMEOUT, BACKEND_REQUEST, COLLECTION_TTL};
 
 use super::momento_error_to_resp_error;
 
@@ -36,8 +36,7 @@ pub async fn hincrby(
             req.key(),
             req.field(),
             req.increment(),
-            None,
-            false,
+            COLLECTION_TTL,
         ),
     )
     .await

--- a/src/proxy/momento/src/protocol/resp/hmget.rs
+++ b/src/proxy/momento/src/protocol/resp/hmget.rs
@@ -21,7 +21,7 @@ pub async fn hmget(
 
     BACKEND_REQUEST.increment();
 
-    let fields: Vec<Vec<u8>> = fields.iter().map(|f| f.as_ref().to_owned()).collect();
+    let fields: Vec<&[u8]> = fields.iter().map(|f| &f[..]).collect();
 
     match timeout(
         Duration::from_millis(200),
@@ -53,7 +53,7 @@ pub async fn hmget(
                         let mut miss = 0;
 
                         for field in &fields {
-                            if let Some(value) = dictionary.get(field) {
+                            if let Some(value) = dictionary.get(*field) {
                                 hit += 1;
                                 klog_2(&"hmget", &key, field, Status::Hit, value.len());
 

--- a/src/proxy/momento/src/protocol/resp/hset.rs
+++ b/src/proxy/momento/src/protocol/resp/hset.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use std::collections::HashMap;
+
 use crate::klog::*;
 use crate::{Error, *};
 use ::net::*;
@@ -54,14 +56,14 @@ pub async fn hset(
 
     BACKEND_REQUEST.increment();
 
-    let mut map = std::collections::HashMap::new();
+    let mut map: HashMap<&[u8], &[u8]> = std::collections::HashMap::new();
     for (field, value) in data.iter() {
-        map.insert(field.as_ref().to_owned(), value.as_ref().to_owned());
+        map.insert(&**field, &**value);
     }
 
     match timeout(
         Duration::from_millis(200),
-        client.dictionary_set(cache_name, key, map.clone(), None, false),
+        client.dictionary_set(cache_name, key, map.clone(), COLLECTION_TTL),
     )
     .await
     {


### PR DESCRIPTION
There's been a few changes in the momento crate's public API. This PR updates the proxy to make use of them.