### PR TITLE
chore: update Brian's email in all toml files

### DIFF
--- a/legacy/deps/ccommon/rust/ccommon-array/Cargo.toml
+++ b/legacy/deps/ccommon/rust/ccommon-array/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccommon-array"
 version = "0.1.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/legacy/deps/ccommon/rust/ccommon-buffer/Cargo.toml
+++ b/legacy/deps/ccommon/rust/ccommon-buffer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccommon-buffer"
 version = "0.1.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/legacy/deps/ccommon/rust/ccommon-channel/Cargo.toml
+++ b/legacy/deps/ccommon/rust/ccommon-channel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccommon-channel"
 version = "0.1.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/legacy/deps/ccommon/rust/ccommon-log/Cargo.toml
+++ b/legacy/deps/ccommon/rust/ccommon-log/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccommon-log"
 version = "0.1.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/legacy/deps/ccommon/rust/ccommon-stats/Cargo.toml
+++ b/legacy/deps/ccommon/rust/ccommon-stats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccommon-stats"
 version = "0.1.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/legacy/deps/ccommon/rust/ccommon-stream/Cargo.toml
+++ b/legacy/deps/ccommon/rust/ccommon-stream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ccommon-stream"
 version = "0.1.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/legacy/deps/ccommon/rust/ccommon-sys/Cargo.toml
+++ b/legacy/deps/ccommon/rust/ccommon-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ccommon-sys"
 version = "0.1.0"
 authors = [
-	"Brian Martin <bmartin@twitter.com>",
+	"Brian Martin <brian@pelikan.io>",
 	"Jonathan Simms <jsimms@twitter.com>",
 	"Sean Lynch <slynch@twitter.com>"
 ]

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "common"
 description = "common types, traits, and helper functions for Pelikan servers"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "config"
 description = "component configurations for Pelikan"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/core/admin/Cargo.toml
+++ b/src/core/admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "admin"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/core/proxy/Cargo.toml
+++ b/src/core/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxy"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/core/server/Cargo.toml
+++ b/src/core/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "server"
 description = "core server event loops and threads for Pelikan servers"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/entrystore/Cargo.toml
+++ b/src/entrystore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "entrystore"
 description = "a collection of entry storage types for use in Pelikan servers"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "net"
 description = "Networking abstractions for non-blocking event loops"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/protocol/admin/Cargo.toml
+++ b/src/protocol/admin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "protocol-admin"
 description = "Admin ASCII protocol used in Pelikan servers"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/protocol/common/Cargo.toml
+++ b/src/protocol/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "protocol-common"
 description = "Traits and shared code for Pelikan protocols"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/protocol/ping/Cargo.toml
+++ b/src/protocol/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-ping"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/protocol/resp/Cargo.toml
+++ b/src/protocol/resp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-resp"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/protocol/thrift/Cargo.toml
+++ b/src/protocol/thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-thrift"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/proxy/ping/Cargo.toml
+++ b/src/proxy/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pingproxy"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/proxy/thrift/Cargo.toml
+++ b/src/proxy/thrift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thriftproxy"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/server/pingserver/Cargo.toml
+++ b/src/server/pingserver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pingserver"
 description = "a simple ascii ping/pong server"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/server/segcache/Cargo.toml
+++ b/src/server/segcache/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "segcache"
 description = "a Memcache protocol server with segment-structured storage"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "session"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/storage/datapool/Cargo.toml
+++ b/src/storage/datapool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datapool"
 description = "abstractions for byte storage pools"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/storage/seg/Cargo.toml
+++ b/src/storage/seg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "seg"
 description = "segment-structured in-memory storage with eager expiration"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }

--- a/src/storage/types/Cargo.toml
+++ b/src/storage/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage-types"
-authors = ["Brian Martin <bmartin@twitter.com>"]
+authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
This email address is unreachable by Brian and leaving it in the repo is not helping anyone who would have a reason to contact him. 

I used the following command to do this:
`fd -e toml -x sd -s "bmartin@twitter.com" "brian@pelikan.io" {}`

which utilizes [fd](https://github.com/sharkdp/fd) and [sd](https://github.com/chmln/sd) which are find and sed replacements (written in Rust), respectively