### PR TITLE
chore: refactor momento frontend to reduce code duplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,7 @@ dependencies = [
  "protocol-resp",
  "session",
  "storage-types",
+ "thiserror",
  "tokio",
 ]
 

--- a/src/protocol/resp/src/request/mod.rs
+++ b/src/protocol/resp/src/request/mod.rs
@@ -293,8 +293,11 @@ impl Request {
             Self::HashSet(_) => "hset",
             Self::HashValues(_) => "hvals",
             Self::HashIncrBy(_) => "hincrby",
+            Self::ListIndex(_) => "lindex",
+            Self::ListLen(_) => "llen",
             Self::Set(_) => "set",
             Self::SetAdd(_) => "sadd",
+            Self::SetRem(_) => "srem",
         }
     }
 }

--- a/src/protocol/resp/src/request/mod.rs
+++ b/src/protocol/resp/src/request/mod.rs
@@ -278,6 +278,25 @@ impl Request {
     ) -> Self {
         Self::Set(Set::new(key, value, expire_time, mode, get_old))
     }
+
+    pub fn command(&self) -> &'static str {
+        match self {
+            Self::BtreeAdd(_) => "badd",
+            Self::Get(_) => "get",
+            Self::HashDelete(_) => "hdel",
+            Self::HashExists(_) => "hexists",
+            Self::HashGet(_) => "hget",
+            Self::HashGetAll(_) => "hgetall",
+            Self::HashKeys(_) => "hkeys",
+            Self::HashLength(_) => "hlen",
+            Self::HashMultiGet(_) => "hmget",
+            Self::HashSet(_) => "hset",
+            Self::HashValues(_) => "hvals",
+            Self::HashIncrBy(_) => "hincrby",
+            Self::Set(_) => "set",
+            Self::SetAdd(_) => "sadd",
+        }
+    }
 }
 
 impl From<BtreeAdd> for Request {

--- a/src/proxy/momento/Cargo.toml
+++ b/src/proxy/momento/Cargo.toml
@@ -25,5 +25,4 @@ protocol-resp = { path = "../../protocol/resp" }
 session = { path = "../../session" }
 storage-types = { path = "../../storage/types" }
 tokio = { version = "1.24.2", features = ["full"] }
-
-thiserror = "1.0.38"
+thiserror = { workspace = true }

--- a/src/proxy/momento/Cargo.toml
+++ b/src/proxy/momento/Cargo.toml
@@ -25,3 +25,5 @@ protocol-resp = { path = "../../protocol/resp" }
 session = { path = "../../session" }
 storage-types = { path = "../../storage/types" }
 tokio = { version = "1.24.2", features = ["full"] }
+
+thiserror = "1.0.38"

--- a/src/proxy/momento/src/error.rs
+++ b/src/proxy/momento/src/error.rs
@@ -1,3 +1,7 @@
+// Copyright 2023 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use momento::MomentoError;
 use thiserror::Error;
 

--- a/src/proxy/momento/src/error.rs
+++ b/src/proxy/momento/src/error.rs
@@ -1,10 +1,10 @@
 use momento::MomentoError;
 use thiserror::Error;
 
-pub(crate) type ProxyResult<T> = Result<T, ProxyError>;
+pub type ProxyResult<T = ()> = Result<T, ProxyError>;
 
 #[derive(Debug, Error)]
-pub(crate) enum ProxyError {
+pub enum ProxyError {
     #[error("momento error: {0}")]
     Momento(#[source] MomentoError),
     #[error("io error: {0}")]

--- a/src/proxy/momento/src/error.rs
+++ b/src/proxy/momento/src/error.rs
@@ -1,0 +1,34 @@
+use momento::MomentoError;
+use thiserror::Error;
+
+pub(crate) type ProxyResult<T> = Result<T, ProxyError>;
+
+#[derive(Debug, Error)]
+pub(crate) enum ProxyError {
+    #[error("momento error: {0}")]
+    Momento(#[source] MomentoError),
+    #[error("io error: {0}")]
+    Io(#[source] std::io::Error),
+    #[error("timeout: {0}")]
+    Timeout(#[source] tokio::time::error::Elapsed),
+    #[error("unsupported resp command")]
+    UnsupportedCommand,
+}
+
+impl From<MomentoError> for ProxyError {
+    fn from(value: MomentoError) -> Self {
+        ProxyError::Momento(value)
+    }
+}
+
+impl From<std::io::Error> for ProxyError {
+    fn from(value: std::io::Error) -> Self {
+        ProxyError::Io(value)
+    }
+}
+
+impl From<tokio::time::error::Elapsed> for ProxyError {
+    fn from(value: tokio::time::error::Elapsed) -> Self {
+        ProxyError::Timeout(value)
+    }
+}

--- a/src/proxy/momento/src/frontend.rs
+++ b/src/proxy/momento/src/frontend.rs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::error::{ProxyError, ProxyResult};
 use crate::protocol::*;
 use crate::*;
+use net::TCP_SEND_BYTE;
 use session::Buf;
 
 pub(crate) async fn handle_memcache_client(
@@ -80,156 +82,125 @@ pub(crate) async fn handle_resp_client(
             break;
         }
 
-        match parser.parse(buf.borrow()) {
-            Ok(request) => {
-                let consumed = request.consumed();
-                let request = request.into_inner();
-
-                match request {
-                    resp::Request::Get(r) => {
-                        if resp::get(&mut client, &cache_name, &mut socket, r.key())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashDelete(r) => {
-                        if resp::hdel(&mut client, &cache_name, &mut socket, r.key(), r.fields())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashExists(r) => {
-                        if resp::hexists(&mut client, &cache_name, &mut socket, r.key(), r.field())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashGet(r) => {
-                        if resp::hget(&mut client, &cache_name, &mut socket, r.key(), r.field())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashGetAll(r) => {
-                        if resp::hgetall(&mut client, &cache_name, &mut socket, r.key())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashIncrBy(r) => {
-                        if resp::hincrby(&mut client, &cache_name, &mut socket, r)
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashKeys(r) => {
-                        if resp::hkeys(&mut client, &cache_name, &mut socket, r.key())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashLength(r) => {
-                        if resp::hlen(&mut client, &cache_name, &mut socket, r.key())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashMultiGet(r) => {
-                        if resp::hmget(&mut client, &cache_name, &mut socket, r.key(), r.fields())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashSet(r) => {
-                        if resp::hset(&mut client, &cache_name, &mut socket, r.key(), r.data())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::HashValues(r) => {
-                        if resp::hvals(&mut client, &cache_name, &mut socket, r.key())
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::ListIndex(r) => {
-                        if resp::lindex(&mut client, &cache_name, &mut socket, r)
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::ListLen(r) => {
-                        if resp::llen(&mut client, &cache_name, &mut socket, r)
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::Set(r) => {
-                        if resp::set(&mut client, &cache_name, &mut socket, &r)
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::SetAdd(r) => {
-                        if resp::sadd(&mut client, &cache_name, &mut socket, &r)
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    resp::Request::SetRem(r) => {
-                        if resp::srem(&mut client, &cache_name, &mut socket, &r)
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    _ => {
-                        println!("bad request");
-                        let _ = socket.write_all(b"CLIENT_ERROR\r\n").await;
-                        break;
-                    }
-                }
-                buf.advance(consumed);
-            }
+        let request = match parser.parse(buf.borrow()) {
+            Ok(request) => request,
             Err(e) => match e.kind() {
-                ErrorKind::WouldBlock => {}
+                ErrorKind::WouldBlock => continue,
                 _ => {
                     println!("bad request");
                     let _ = socket.write_all(b"CLIENT_ERROR\r\n").await;
                     break;
                 }
             },
+        };
+
+        let consumed = request.consumed();
+        let request = request.into_inner();
+        let command = request.command();
+
+        let mut response_buf = Vec::<u8>::new();
+
+        let result: ProxyResult<()> = async {
+            match &request {
+                resp::Request::Get(r) => {
+                    resp::get(&mut client, &cache_name, &mut socket, r.key()).await?
+                }
+                resp::Request::HashDelete(r) => {
+                    resp::hdel(&mut client, &cache_name, &mut socket, r.key(), r.fields()).await?
+                }
+                resp::Request::HashExists(r) => {
+                    resp::hexists(&mut client, &cache_name, &mut socket, r.key(), r.field()).await?
+                }
+                resp::Request::HashGet(r) => {
+                    resp::hget(&mut client, &cache_name, &mut socket, r.key(), r.field()).await?
+                }
+                resp::Request::HashGetAll(r) => {
+                    resp::hgetall(&mut client, &cache_name, &mut socket, r.key()).await?
+                }
+                resp::Request::HashIncrBy(r) => {
+                    resp::hincrby(&mut client, &cache_name, &mut socket, r).await?
+                }
+                resp::Request::HashKeys(r) => {
+                    resp::hkeys(&mut client, &cache_name, &mut socket, r.key()).await?
+                }
+                resp::Request::HashLength(r) => {
+                    resp::hlen(&mut client, &cache_name, &mut socket, r.key()).await?
+                }
+                resp::Request::HashMultiGet(r) => {
+                    resp::hmget(&mut client, &cache_name, &mut socket, r.key(), r.fields()).await?
+                }
+                resp::Request::HashSet(r) => {
+                    resp::hset(&mut client, &cache_name, &mut socket, r.key(), r.data()).await?
+                }
+                resp::Request::HashValues(r) => {
+                    resp::hvals(&mut client, &cache_name, &mut socket, r.key()).await?
+                }
+                resp::Request::ListIndex(r) => {
+                    resp::lindex(&mut client, &cache_name, &mut socket, r).await?
+                }
+                resp::Request::ListLen(r) => {
+                    resp::llen(&mut client, &cache_name, &mut socket, r).await?
+                }
+                resp::Request::Set(r) => {
+                    resp::set(&mut client, &cache_name, &mut socket, &r).await?
+                }
+                resp::Request::SetAdd(r) => {
+                    resp::sadd(&mut client, &cache_name, &mut socket, &r).await?
+                }
+                resp::Request::SetRem(r) => {
+                    resp::srem(&mut client, &cache_name, &mut socket, &r).await?
+                }
+                _ => return Err(ProxyError::UnsupportedCommand),
+            }
+
+            Ok(())
         }
+        .await;
+
+        let fatal = match result {
+            Ok(()) => false,
+            Err(e) => {
+                response_buf.clear();
+
+                match e {
+                    ProxyError::Momento(error) => {
+                        crate::protocol::resp::momento_error_to_resp_error(
+                            &mut response_buf,
+                            command,
+                            error,
+                        );
+
+                        false
+                    }
+                    ProxyError::Timeout(_) => {
+                        BACKEND_EX.increment();
+                        BACKEND_EX_TIMEOUT.increment();
+                        response_buf.extend_from_slice(b"-ERR backend timeout\r\n");
+
+                        false
+                    }
+                    ProxyError::Io(_) => true,
+                    ProxyError::UnsupportedCommand => {
+                        println!("bad request");
+                        response_buf.extend_from_slice(b"CLIENT_ERROR\r\n");
+                        true
+                    }
+                }
+            }
+        };
+
+        SESSION_SEND_BYTE.add(response_buf.len() as _);
+        TCP_SEND_BYTE.add(response_buf.len() as _);
+
+        if let Err(_) = socket.write_all(&response_buf).await {
+            SESSION_SEND_EX.increment();
+            break;
+        }
+
+        if fatal {
+            break;
+        }
+
+        buf.advance(consumed);
     }
 }

--- a/src/proxy/momento/src/frontend.rs
+++ b/src/proxy/momento/src/frontend.rs
@@ -105,7 +105,7 @@ pub(crate) async fn handle_resp_client(
                     resp::get(&mut client, &cache_name, &mut response_buf, r.key()).await?
                 }
                 resp::Request::HashDelete(r) => {
-                    resp::hdel(&mut client, &cache_name, &mut socket, r.key(), r.fields()).await?
+                    resp::hdel(&mut client, &cache_name, &mut response_buf, r).await?
                 }
                 resp::Request::HashExists(r) => {
                     resp::hexists(&mut client, &cache_name, &mut socket, r.key(), r.field()).await?

--- a/src/proxy/momento/src/main.rs
+++ b/src/proxy/momento/src/main.rs
@@ -27,6 +27,8 @@ use tokio::net::TcpListener;
 use tokio::runtime::Builder;
 use tokio::time::timeout;
 
+use crate::error::{ProxyError, ProxyResult};
+
 pub const KB: usize = 1024;
 pub const MB: usize = 1024 * KB;
 

--- a/src/proxy/momento/src/main.rs
+++ b/src/proxy/momento/src/main.rs
@@ -34,6 +34,7 @@ const S: u64 = 1_000_000_000; // one second in nanoseconds
 const US: u64 = 1_000; // one microsecond in nanoseconds
 
 mod admin;
+mod error;
 mod frontend;
 mod klog;
 mod listener;

--- a/src/proxy/momento/src/protocol/resp/get.rs
+++ b/src/proxy/momento/src/protocol/resp/get.rs
@@ -3,97 +3,48 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::klog::{klog_1, Status};
-use crate::{Error, *};
-use ::net::*;
+use crate::*;
 use protocol_memcache::*;
 
 pub async fn get(
     client: &mut SimpleCacheClient,
     cache_name: &str,
-    socket: &mut tokio::net::TcpStream,
+    response_buf: &mut Vec<u8>,
     key: &[u8],
-) -> Result<(), Error> {
+) -> ProxyResult {
     GET.increment();
-
-    // check if any of the key is invalid
-    if std::str::from_utf8(key).is_err() {
-        GET_EX.increment();
-
-        // invalid key
-        let _ = socket.write_all(b"-ERR invalid key\r\n").await;
-        return Err(Error::from(ErrorKind::InvalidInput));
-    }
-
-    let mut response_buf = Vec::new();
-
-    BACKEND_REQUEST.increment();
     GET_KEY.increment();
+    BACKEND_REQUEST.increment();
 
-    // we've already checked the keys, so we
-    // know this unwrap is safe
-    let key = std::str::from_utf8(key).unwrap();
-
-    match timeout(Duration::from_millis(200), client.get(cache_name, key)).await {
-        Ok(Ok(response)) => {
-            match response.result {
-                MomentoGetStatus::ERROR => {
-                    // we got some error from
-                    // the backend.
-                    BACKEND_EX.increment();
-                    GET_EX.increment();
-                    response_buf.extend_from_slice(b"-ERR backend error\r\n");
-                }
-                MomentoGetStatus::HIT => {
-                    GET_KEY_HIT.increment();
-
-                    let item_header = format!("${}\r\n", response.value.len());
-
-                    response_buf.extend_from_slice(item_header.as_bytes());
-                    response_buf.extend_from_slice(&response.value);
-                    response_buf.extend_from_slice(b"\r\n");
-
-                    klog_1(&"get", &key, Status::Hit, response.value.len());
-                }
-                MomentoGetStatus::MISS => {
-                    GET_KEY_MISS.increment();
-
-                    response_buf.extend_from_slice(b"$-1\r\n");
-
-                    klog_1(&"get", &key, Status::Miss, 0);
-                }
-            }
-        }
-        Ok(Err(MomentoError::LimitExceeded(_))) => {
-            BACKEND_EX.increment();
-            BACKEND_EX_RATE_LIMITED.increment();
-            GET_EX.increment();
-            response_buf.extend_from_slice(b"-ERR ratelimit exceed\r\n");
-        }
-        Ok(Err(e)) => {
-            // we got some error from the momento client
-            // log and incr stats and move on treating it
-            // as an error
-            error!("error for get: {}", e);
+    let response = timeout(Duration::from_millis(200), client.get(cache_name, key)).await??;
+    match response.result {
+        MomentoGetStatus::ERROR => {
+            // we got some error from
+            // the backend.
             BACKEND_EX.increment();
             GET_EX.increment();
             response_buf.extend_from_slice(b"-ERR backend error\r\n");
         }
-        Err(_) => {
-            // we had a timeout, incr stats and move on
-            // treating it as an error
-            BACKEND_EX.increment();
-            BACKEND_EX_TIMEOUT.increment();
-            GET_EX.increment();
-            response_buf.extend_from_slice(b"-ERR backend timeout\r\n");
+        MomentoGetStatus::HIT => {
+            GET_KEY_HIT.increment();
+
+            let item_header = format!("${}\r\n", response.value.len());
+
+            response_buf.extend_from_slice(item_header.as_bytes());
+            response_buf.extend_from_slice(&response.value);
+            response_buf.extend_from_slice(b"\r\n");
+
+            klog_1(&"get", &key, Status::Hit, response.value.len());
+        }
+        MomentoGetStatus::MISS => {
+            GET_KEY_MISS.increment();
+
+            response_buf.extend_from_slice(b"$-1\r\n");
+
+            klog_1(&"get", &key, Status::Miss, 0);
         }
     }
 
     SESSION_SEND.increment();
-    SESSION_SEND_BYTE.add(response_buf.len() as _);
-    TCP_SEND_BYTE.add(response_buf.len() as _);
-    if let Err(e) = socket.write_all(&response_buf).await {
-        SESSION_SEND_EX.increment();
-        return Err(e);
-    }
     Ok(())
 }

--- a/src/proxy/momento/src/protocol/resp/get.rs
+++ b/src/proxy/momento/src/protocol/resp/get.rs
@@ -6,14 +6,15 @@ use crate::klog::{klog_1, Status};
 use crate::*;
 use protocol_memcache::*;
 
+use super::update_method_metrics;
+
 pub async fn get(
     client: &mut SimpleCacheClient,
     cache_name: &str,
     response_buf: &mut Vec<u8>,
     key: &[u8],
 ) -> ProxyResult {
-    let inner = async move {
-        GET.increment();
+    update_method_metrics(&GET, &GET_EX, async move {
         GET_KEY.increment();
 
         let response = timeout(Duration::from_millis(200), client.get(cache_name, key)).await??;
@@ -46,10 +47,6 @@ pub async fn get(
         }
 
         Ok(())
-    };
-
-    inner.await.map_err(|e| {
-        GET_EX.increment();
-        e
     })
+    .await
 }

--- a/src/proxy/momento/src/protocol/resp/get.rs
+++ b/src/proxy/momento/src/protocol/resp/get.rs
@@ -14,7 +14,6 @@ pub async fn get(
 ) -> ProxyResult {
     GET.increment();
     GET_KEY.increment();
-    BACKEND_REQUEST.increment();
 
     let response = timeout(Duration::from_millis(200), client.get(cache_name, key)).await??;
     match response.result {
@@ -45,6 +44,5 @@ pub async fn get(
         }
     }
 
-    SESSION_SEND.increment();
     Ok(())
 }

--- a/src/proxy/momento/src/protocol/resp/hdel.rs
+++ b/src/proxy/momento/src/protocol/resp/hdel.rs
@@ -3,87 +3,39 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::klog::*;
-use crate::{Error, *};
-use ::net::*;
+use crate::*;
 use protocol_resp::*;
-use std::sync::Arc;
+use std::io::Write;
 
 pub async fn hdel(
     client: &mut SimpleCacheClient,
     cache_name: &str,
-    socket: &mut tokio::net::TcpStream,
-    key: &[u8],
-    fields: &[Arc<[u8]>],
-) -> Result<(), Error> {
-    HDEL.increment();
+    response_buf: &mut Vec<u8>,
+    req: &HashDelete,
+) -> ProxyResult {
+    let inner = async move {
+        HDEL.increment();
 
-    // check if the fields are valid before
-    // sending the request to the backend
-    for field in fields.iter() {
-        if std::str::from_utf8(field).is_err() {
-            HMGET_EX.increment();
+        let fields: Vec<&[u8]> = req.fields().iter().map(|f| &**f).collect();
+        timeout(
+            Duration::from_millis(200),
+            client.dictionary_delete(cache_name, req.key(), Fields::Some(fields)),
+        )
+        .await??;
 
-            // invalid field
-            let _ = socket.write_all(b"-ERR invalid field\r\n").await;
-            return Err(Error::from(ErrorKind::InvalidInput));
+        // NOTE: the Momento protocol does not inform us of how many fields are
+        // deleted. We lie to the client and say that they all were deleted.
+        write!(response_buf, ":{}\r\n", req.fields().len())?;
+
+        for field in req.fields() {
+            klog_2(&"hdel", &req.key(), field, Status::Deleted, 0);
         }
-    }
 
-    let mut response_buf = Vec::new();
+        Ok(())
+    };
 
-    BACKEND_REQUEST.increment();
-
-    let fields: Vec<String> = fields
-        .iter()
-        .map(|f| std::str::from_utf8(f).unwrap().to_owned())
-        .collect();
-
-    match timeout(
-        Duration::from_millis(200),
-        client.dictionary_delete(cache_name, key, Fields::Some(fields.clone())),
-    )
-    .await
-    {
-        Ok(Ok(_)) => {
-            // NOTE: the Momento protocol does not inform us of how many fields are
-            // deleted. We lie to the client and say that they all were deleted.
-            response_buf.extend_from_slice(format!(":{}\r\n", fields.len()).as_bytes());
-
-            for field in &fields {
-                klog_2(&"hdel", &key, field, Status::Deleted, 0);
-            }
-        }
-        Ok(Err(MomentoError::LimitExceeded(_))) => {
-            BACKEND_EX.increment();
-            BACKEND_EX_RATE_LIMITED.increment();
-            HDEL_EX.increment();
-            response_buf.extend_from_slice(b"-ERR ratelimit exceed\r\n");
-        }
-        Ok(Err(e)) => {
-            // we got some error from the momento client
-            // log and incr stats and move on treating it
-            // as an error
-            error!("error for hdel: {}", e);
-            BACKEND_EX.increment();
-            HDEL_EX.increment();
-            response_buf.extend_from_slice(b"-ERR backend error\r\n");
-        }
-        Err(_) => {
-            // we had a timeout, incr stats and move on
-            // treating it as an error
-            BACKEND_EX.increment();
-            BACKEND_EX_TIMEOUT.increment();
-            HDEL_EX.increment();
-            response_buf.extend_from_slice(b"-ERR backend timeout\r\n");
-        }
-    }
-
-    SESSION_SEND.increment();
-    SESSION_SEND_BYTE.add(response_buf.len() as _);
-    TCP_SEND_BYTE.add(response_buf.len() as _);
-    if let Err(e) = socket.write_all(&response_buf).await {
-        SESSION_SEND_EX.increment();
-        return Err(e);
-    }
-    Ok(())
+    inner.await.map_err(|e| {
+        HDEL_EX.increment();
+        e
+    })
 }

--- a/src/proxy/momento/src/protocol/resp/hdel.rs
+++ b/src/proxy/momento/src/protocol/resp/hdel.rs
@@ -7,13 +7,15 @@ use crate::*;
 use protocol_resp::*;
 use std::io::Write;
 
+use super::update_method_metrics;
+
 pub async fn hdel(
     client: &mut SimpleCacheClient,
     cache_name: &str,
     response_buf: &mut Vec<u8>,
     req: &HashDelete,
 ) -> ProxyResult {
-    let inner = async move {
+    update_method_metrics(&HDEL, &HDEL_EX, async move {
         HDEL.increment();
 
         let fields: Vec<&[u8]> = req.fields().iter().map(|f| &**f).collect();
@@ -32,10 +34,6 @@ pub async fn hdel(
         }
 
         Ok(())
-    };
-
-    inner.await.map_err(|e| {
-        HDEL_EX.increment();
-        e
     })
+    .await
 }

--- a/src/proxy/momento/src/protocol/resp/hdel.rs
+++ b/src/proxy/momento/src/protocol/resp/hdel.rs
@@ -16,8 +16,6 @@ pub async fn hdel(
     req: &HashDelete,
 ) -> ProxyResult {
     update_method_metrics(&HDEL, &HDEL_EX, async move {
-        HDEL.increment();
-
         let fields: Vec<&[u8]> = req.fields().iter().map(|f| &**f).collect();
         timeout(
             Duration::from_millis(200),

--- a/src/proxy/momento/src/protocol/resp/hincrby.rs
+++ b/src/proxy/momento/src/protocol/resp/hincrby.rs
@@ -22,7 +22,7 @@ pub async fn hincrby(
     client: &mut SimpleCacheClient,
     cache_name: &str,
     socket: &mut TcpStream,
-    req: HashIncrBy,
+    req: &HashIncrBy,
 ) -> std::io::Result<()> {
     HINCRBY.increment();
     BACKEND_REQUEST.increment();

--- a/src/proxy/momento/src/protocol/resp/lindex.rs
+++ b/src/proxy/momento/src/protocol/resp/lindex.rs
@@ -22,7 +22,7 @@ pub async fn lindex(
     client: &mut SimpleCacheClient,
     cache_name: &str,
     socket: &mut TcpStream,
-    req: ListIndex,
+    req: &ListIndex,
 ) -> std::io::Result<()> {
     LINDEX.increment();
     BACKEND_REQUEST.increment();

--- a/src/proxy/momento/src/protocol/resp/llen.rs
+++ b/src/proxy/momento/src/protocol/resp/llen.rs
@@ -22,7 +22,7 @@ pub async fn llen(
     client: &mut SimpleCacheClient,
     cache_name: &str,
     socket: &mut TcpStream,
-    req: ListLen,
+    req: &ListLen,
 ) -> std::io::Result<()> {
     LLEN.increment();
     BACKEND_REQUEST.increment();

--- a/src/proxy/momento/src/protocol/resp/mod.rs
+++ b/src/proxy/momento/src/protocol/resp/mod.rs
@@ -39,7 +39,7 @@ pub use hvals::*;
 pub use sadd::*;
 pub use set::*;
 
-fn momento_error_to_resp_error(buf: &mut Vec<u8>, command: &str, error: MomentoError) {
+pub(crate) fn momento_error_to_resp_error(buf: &mut Vec<u8>, command: &str, error: MomentoError) {
     use crate::{BACKEND_EX, BACKEND_EX_RATE_LIMITED, BACKEND_EX_TIMEOUT};
 
     BACKEND_EX.increment();


### PR DESCRIPTION
The command handling in the momento proxy has a _lot_ of duplicated code (about 60% of lines for each new command are copy-paste). By refactoring things I have moved the common code up one level so that common error handling and metrics work no longer needs to be copy-pasted in to each new function.

The detailed changes are as follows:
- Introduce a new error type that covers all error cases encountered in the resp client.
- Move common metric updates up into `handle_resp_client` using the error type above to figure out what needs to be updated.
- Update `GET` and `HDEL` to take advantage of this as an example of the benefits.

I haven't updated all the commands yet, that will happen once I've finished up what I need to do for momento and have some time to cover the remaining commands.