### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/src/config/src/debug.rs
+++ b/src/config/src/debug.rs
@@ -82,7 +82,7 @@ impl Debug {
     pub fn log_backup(&self) -> Option<String> {
         match &self.log_backup {
             Some(path) => Some(path.clone()),
-            None => self.log_file.as_ref().map(|path| format!("{}.old", path)),
+            None => self.log_file.as_ref().map(|path| format!("{path}.old")),
         }
     }
 

--- a/src/config/src/klog.rs
+++ b/src/config/src/klog.rs
@@ -96,7 +96,7 @@ impl Klog {
     pub fn backup(&self) -> Option<String> {
         match &self.backup {
             Some(path) => Some(path.clone()),
-            None => self.file.as_ref().map(|path| format!("{}.old", path)),
+            None => self.file.as_ref().map(|path| format!("{path}.old")),
         }
     }
 

--- a/src/config/src/momento_proxy.rs
+++ b/src/config/src/momento_proxy.rs
@@ -94,7 +94,7 @@ impl MomentoProxyConfig {
         match toml::from_str(&content) {
             Ok(t) => Ok(t),
             Err(e) => {
-                eprintln!("{}", e);
+                eprintln!("{e}");
                 Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "Error parsing config",

--- a/src/config/src/proxy.rs
+++ b/src/config/src/proxy.rs
@@ -171,7 +171,7 @@ impl Backend {
                 if let Ok(children) = server.get_children(path, true) {
                     for child in children {
                         let data = server
-                            .get_data(&format!("{}/{}", path, child), true)
+                            .get_data(&format!("{path}/{child}"), true)
                             .map(|v| {
                                 std::str::from_utf8(&v.0)
                                     .map_err(|_| {
@@ -200,7 +200,7 @@ impl Backend {
                         let host_parts: Vec<&str> = host.split('"').collect();
                         let port = endpoint["port"].to_string();
                         if let Some(host) = host_parts.get(1) {
-                            let host = format!("{}:{}", host, port);
+                            let host = format!("{host}:{port}");
                             if let Ok(mut addrs) = host.to_socket_addrs() {
                                 if let Some(socket_addr) = addrs.next() {
                                     ret.push(socket_addr);

--- a/src/config/src/segcache.rs
+++ b/src/config/src/segcache.rs
@@ -73,7 +73,7 @@ impl SegcacheConfig {
         match toml::from_str(&content) {
             Ok(t) => Ok(t),
             Err(e) => {
-                eprintln!("{}", e);
+                eprintln!("{e}");
                 Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "Error parsing config",
@@ -97,7 +97,7 @@ impl SegcacheConfig {
     /// Prints the configuration
     pub fn print(&self) {
         let config_toml = self.render_config();
-        println!("Segcache configuration:\n\n{}", config_toml);
+        println!("Segcache configuration:\n\n{config_toml}");
     }
 
     /// Renders the configuration as a printable string

--- a/src/core/proxy/src/process.rs
+++ b/src/core/proxy/src/process.rs
@@ -123,12 +123,12 @@ where
                 .build(fe_data_queues, worker_session_queues, signal_queue_rx);
 
         let admin = std::thread::Builder::new()
-            .name(format!("{}_admin", THREAD_PREFIX))
+            .name(format!("{THREAD_PREFIX}_admin"))
             .spawn(move || admin.run())
             .unwrap();
 
         let listener = std::thread::Builder::new()
-            .name(format!("{}_listener", THREAD_PREFIX))
+            .name(format!("{THREAD_PREFIX}_listener"))
             .spawn(move || listener.run())
             .unwrap();
 
@@ -137,7 +137,7 @@ where
             .enumerate()
             .map(|(i, mut b)| {
                 std::thread::Builder::new()
-                    .name(format!("{}_be_{}", THREAD_PREFIX, i))
+                    .name(format!("{THREAD_PREFIX}_be_{i}"))
                     .spawn(move || b.run())
                     .unwrap()
             })
@@ -148,7 +148,7 @@ where
             .enumerate()
             .map(|(i, mut f)| {
                 std::thread::Builder::new()
-                    .name(format!("{}_fe_{}", THREAD_PREFIX, i))
+                    .name(format!("{THREAD_PREFIX}_fe_{i}"))
                     .spawn(move || f.run())
                     .unwrap()
             })

--- a/src/core/server/src/process.rs
+++ b/src/core/server/src/process.rs
@@ -71,12 +71,12 @@ where
         let workers = self.workers.build(worker_session_queues, signal_queue_rx);
 
         let admin = std::thread::Builder::new()
-            .name(format!("{}_admin", THREAD_PREFIX))
+            .name(format!("{THREAD_PREFIX}_admin"))
             .spawn(move || admin.run())
             .unwrap();
 
         let listener = std::thread::Builder::new()
-            .name(format!("{}_listener", THREAD_PREFIX))
+            .name(format!("{THREAD_PREFIX}_listener"))
             .spawn(move || listener.run())
             .unwrap();
 

--- a/src/core/server/src/workers/mod.rs
+++ b/src/core/server/src/workers/mod.rs
@@ -63,7 +63,7 @@ where
         match self {
             Self::Single { mut worker } => {
                 vec![std::thread::Builder::new()
-                    .name(format!("{}_work", THREAD_PREFIX))
+                    .name(format!("{THREAD_PREFIX}_work"))
                     .spawn(move || worker.run())
                     .unwrap()]
             }
@@ -72,14 +72,14 @@ where
                 mut storage,
             } => {
                 let mut join_handles = vec![std::thread::Builder::new()
-                    .name(format!("{}_storage", THREAD_PREFIX))
+                    .name(format!("{THREAD_PREFIX}_storage"))
                     .spawn(move || storage.run())
                     .unwrap()];
 
                 for (id, mut worker) in workers.drain(..).enumerate() {
                     join_handles.push(
                         std::thread::Builder::new()
-                            .name(format!("{}_work_{}", THREAD_PREFIX, id))
+                            .name(format!("{THREAD_PREFIX}_work_{id}"))
                             .spawn(move || worker.run())
                             .unwrap(),
                     )

--- a/src/entrystore/src/seg/memcache.rs
+++ b/src/entrystore/src/seg/memcache.rs
@@ -48,7 +48,7 @@ impl Storage for Seg {
                             item.key(),
                             flags,
                             None,
-                            format!("{}", v).as_bytes(),
+                            format!("{v}").as_bytes(),
                         ));
                     }
                 }
@@ -74,7 +74,7 @@ impl Storage for Seg {
                             item.key(),
                             flags,
                             Some(item.cas().into()),
-                            format!("{}", v).as_bytes(),
+                            format!("{v}").as_bytes(),
                         ));
                     }
                 }

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -62,7 +62,7 @@ pub fn configure_logging<T: DebugConfig + KlogConfig>(config: &T) -> Box<dyn Dra
     let debug_config = config.debug();
 
     let debug_output: Box<dyn Output> = if let Some(file) = debug_config.log_file() {
-        let backup = debug_config.log_backup().unwrap_or(format!("{}.old", file));
+        let backup = debug_config.log_backup().unwrap_or(format!("{file}.old"));
         Box::new(
             File::new(&file, &backup, debug_config.log_max_size())
                 .expect("failed to open debug log file"),
@@ -81,7 +81,7 @@ pub fn configure_logging<T: DebugConfig + KlogConfig>(config: &T) -> Box<dyn Dra
     let klog_config = config.klog();
 
     let klog = if let Some(file) = klog_config.file() {
-        let backup = klog_config.backup().unwrap_or(format!("{}.old", file));
+        let backup = klog_config.backup().unwrap_or(format!("{file}.old"));
         let output = Box::new(
             File::new(&file, &backup, klog_config.max_size()).expect("failed to open klog file"),
         );

--- a/src/net/src/stream.rs
+++ b/src/net/src/stream.rs
@@ -91,8 +91,8 @@ impl Drop for Stream {
 impl Debug for Stream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         match &self.inner {
-            StreamType::Tcp(s) => write!(f, "{:?}", s),
-            StreamType::TlsTcp(s) => write!(f, "{:?}", s),
+            StreamType::Tcp(s) => write!(f, "{s:?}"),
+            StreamType::TlsTcp(s) => write!(f, "{s:?}"),
         }
     }
 }

--- a/src/net/src/tcp.rs
+++ b/src/net/src/tcp.rs
@@ -296,10 +296,10 @@ mod tests {
                     .expect("failed to write");
             }
             Ok(n) => {
-                panic!("read: {} bytes but expected 6", n);
+                panic!("read: {n} bytes but expected 6");
             }
             Err(e) => {
-                panic!("error reading: {}", e);
+                panic!("error reading: {e}");
             }
         }
 
@@ -310,10 +310,10 @@ mod tests {
                 assert_eq!(&buf[0..6], b"PONG\r\n");
             }
             Ok(n) => {
-                panic!("read: {} bytes but expected 6", n);
+                panic!("read: {n} bytes but expected 6");
             }
             Err(e) => {
-                panic!("error reading: {}", e);
+                panic!("error reading: {e}");
             }
         }
     }

--- a/src/net/src/tls_tcp.rs
+++ b/src/net/src/tls_tcp.rs
@@ -445,7 +445,7 @@ impl TlsTcpConnectorBuilder {
         // load the CA file, if provided
         if let Some(f) = self.ca_file {
             self.inner.set_ca_file(f).map_err(|e| {
-                Error::new(ErrorKind::Other, format!("failed to load CA file: {}", e))
+                Error::new(ErrorKind::Other, format!("failed to load CA file: {e}"))
             })?;
         }
 
@@ -456,7 +456,7 @@ impl TlsTcpConnectorBuilder {
                 .map_err(|e| {
                     Error::new(
                         ErrorKind::Other,
-                        format!("failed to load private key file: {}", e),
+                        format!("failed to load private key file: {e}"),
                     )
                 })?;
         } else {
@@ -475,7 +475,7 @@ impl TlsTcpConnectorBuilder {
                     .map_err(|e| {
                         Error::new(
                             ErrorKind::Other,
-                            format!("failed to load certificate file: {}", e),
+                            format!("failed to load certificate file: {e}"),
                         )
                     })?;
 
@@ -483,20 +483,20 @@ impl TlsTcpConnectorBuilder {
                 let pem = std::fs::read(chain).map_err(|e| {
                     Error::new(
                         ErrorKind::Other,
-                        format!("failed to load certificate chain file: {}", e),
+                        format!("failed to load certificate chain file: {e}"),
                     )
                 })?;
                 let chain = X509::stack_from_pem(&pem).map_err(|e| {
                     Error::new(
                         ErrorKind::Other,
-                        format!("failed to load certificate chain file: {}", e),
+                        format!("failed to load certificate chain file: {e}"),
                     )
                 })?;
                 for cert in chain {
                     self.inner.add_extra_chain_cert(cert).map_err(|e| {
                         Error::new(
                             ErrorKind::Other,
-                            format!("bad certificate in certificate chain file: {}", e),
+                            format!("bad certificate in certificate chain file: {e}"),
                         )
                     })?;
                 }
@@ -509,7 +509,7 @@ impl TlsTcpConnectorBuilder {
                 self.inner.set_certificate_chain_file(chain).map_err(|e| {
                     Error::new(
                         ErrorKind::Other,
-                        format!("failed to load certificate chain file: {}", e),
+                        format!("failed to load certificate chain file: {e}"),
                     )
                 })?;
             }
@@ -520,7 +520,7 @@ impl TlsTcpConnectorBuilder {
                     .map_err(|e| {
                         Error::new(
                             ErrorKind::Other,
-                            format!("failed to load certificate file: {}", e),
+                            format!("failed to load certificate file: {e}"),
                         )
                     })?;
             }

--- a/src/protocol/http/src/error.rs
+++ b/src/protocol/http/src/error.rs
@@ -30,7 +30,7 @@ impl Error {
             Self::Unparseable(e) => Response::builder(400)
                 .should_close(true)
                 .header("Content-Type", b"text/plain")
-                .body(format!("Unable to parse request: {}", e).as_bytes()),
+                .body(format!("Unable to parse request: {e}").as_bytes()),
             Self::BadRequestMethod => Response::builder(405)
                 .should_close(true)
                 .header("Content-Type", b"text/plain")

--- a/src/protocol/resp/src/request/sadd.rs
+++ b/src/protocol/resp/src/request/sadd.rs
@@ -73,7 +73,7 @@ impl From<&SetAdd> for Message {
             value
                 .members()
                 .iter()
-                .map(|v| Message::BulkString(BulkString::new(&**v))),
+                .map(|v| Message::BulkString(BulkString::new(v))),
         );
 
         Message::Array(Array { inner: Some(vals) })

--- a/src/protocol/resp/src/request/set.rs
+++ b/src/protocol/resp/src/request/set.rs
@@ -190,19 +190,19 @@ impl From<&Set> for Message {
         match other.expire_time {
             Some(ExpireTime::Seconds(s)) => {
                 v.push(Message::bulk_string(b"EX"));
-                v.push(Message::bulk_string(format!("{}", s).as_bytes()));
+                v.push(Message::bulk_string(format!("{s}").as_bytes()));
             }
             Some(ExpireTime::Milliseconds(ms)) => {
                 v.push(Message::bulk_string(b"PX"));
-                v.push(Message::bulk_string(format!("{}", ms).as_bytes()));
+                v.push(Message::bulk_string(format!("{ms}").as_bytes()));
             }
             Some(ExpireTime::UnixSeconds(s)) => {
                 v.push(Message::bulk_string(b"EXAT"));
-                v.push(Message::bulk_string(format!("{}", s).as_bytes()));
+                v.push(Message::bulk_string(format!("{s}").as_bytes()));
             }
             Some(ExpireTime::UnixMilliseconds(ms)) => {
                 v.push(Message::bulk_string(b"PXAT"));
-                v.push(Message::bulk_string(format!("{}", ms).as_bytes()));
+                v.push(Message::bulk_string(format!("{ms}").as_bytes()));
             }
             Some(ExpireTime::KeepTtl) => {
                 v.push(Message::bulk_string(b"KEEPTTL"));

--- a/src/protocol/resp/src/request/srem.rs
+++ b/src/protocol/resp/src/request/srem.rs
@@ -72,7 +72,7 @@ impl From<&SetRem> for Message {
             value
                 .members()
                 .iter()
-                .map(|v| Message::BulkString(BulkString::new(&**v))),
+                .map(|v| Message::BulkString(BulkString::new(v))),
         );
 
         Message::Array(Array { inner: Some(vals) })

--- a/src/protocol/resp/src/util.rs
+++ b/src/protocol/resp/src/util.rs
@@ -94,17 +94,15 @@ pub fn take_bulk_string_as_i64(array: &mut Vec<Message>) -> Result<Option<i64>, 
             let text = value
                 .inner
                 .ok_or_else(|| Error::new(ErrorKind::Other, "bulk string is null"))?;
-            std::str::from_utf8(&*text)
+            std::str::from_utf8(&text)
                 .map_err(|_| Error::new(ErrorKind::Other, "bulk string not valid utf8"))?
                 .parse::<i64>()
                 .map_err(|_| Error::new(ErrorKind::Other, "bulk string is not a i64"))
                 .map(Some)
         }
-        _ => {
-            return Err(Error::new(
-                ErrorKind::Other,
-                "next array element is not a bulk string",
-            ))
-        }
+        _ => Err(Error::new(
+            ErrorKind::Other,
+            "next array element is not a bulk string",
+        )),
     }
 }

--- a/src/proxy/momento/src/main.rs
+++ b/src/proxy/momento/src/main.rs
@@ -148,7 +148,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         match MomentoProxyConfig::load(file) {
             Ok(c) => c,
             Err(e) => {
-                println!("{}", e);
+                println!("{e}");
                 std::process::exit(1);
             }
         }
@@ -205,7 +205,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             } else if any.downcast_ref::<Heatmap>().is_some() {
                 for (label, _) in PERCENTILES {
                     let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{:<31} percentile", name));
+                    metrics.push(format!("{name:<31} percentile"));
                 }
             } else {
                 continue;
@@ -214,7 +214,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         metrics.sort();
         for metric in metrics {
-            println!("{}", metric);
+            println!("{metric}");
         }
         std::process::exit(0);
     }
@@ -224,7 +224,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     runtime.thread_name_fn(|| {
         static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
         let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-        format!("pelikan_wrk_{}", id)
+        format!("pelikan_wrk_{id}")
     });
 
     if let Some(threads) = config.threads() {

--- a/src/proxy/momento/src/protocol/memcache/get.rs
+++ b/src/proxy/momento/src/protocol/memcache/get.rs
@@ -59,7 +59,7 @@ pub async fn get(
 
                         let length = response.value.len();
 
-                        let item_header = format!("VALUE {} 0 {}\r\n", key, length);
+                        let item_header = format!("VALUE {key} 0 {length}\r\n");
 
                         klog_1(&"get", &key, Status::Hit, length);
 

--- a/src/proxy/momento/src/protocol/resp/llen.rs
+++ b/src/proxy/momento/src/protocol/resp/llen.rs
@@ -31,7 +31,7 @@ pub async fn llen(
 
     match timeout(
         Duration::from_millis(200),
-        client.list_length(&cache_name, req.key()),
+        client.list_length(cache_name, req.key()),
     )
     .await
     {

--- a/src/proxy/momento/src/protocol/resp/sadd.rs
+++ b/src/proxy/momento/src/protocol/resp/sadd.rs
@@ -27,7 +27,7 @@ pub async fn sadd(
     BACKEND_REQUEST.increment();
 
     let mut response_buf = Vec::new();
-    let elements = req.members().into_iter().map(|e| &**e).collect();
+    let elements = req.members().iter().map(|e| &**e).collect();
 
     match timeout(
         Duration::from_millis(200),

--- a/src/proxy/momento/src/protocol/resp/srem.rs
+++ b/src/proxy/momento/src/protocol/resp/srem.rs
@@ -28,7 +28,7 @@ pub async fn srem(
     BACKEND_REQUEST.increment();
 
     let mut response_buf = Vec::new();
-    let elements = req.members().into_iter().map(|e| &**e).collect();
+    let elements = req.members().iter().map(|e| &**e).collect();
 
     match timeout(
         Duration::from_millis(200),

--- a/src/proxy/ping/src/main.rs
+++ b/src/proxy/ping/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
             } else if any.downcast_ref::<Heatmap>().is_some() {
                 for (label, _) in PERCENTILES {
                     let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{:<31} percentile", name));
+                    metrics.push(format!("{name:<31} percentile"));
                 }
             } else {
                 continue;
@@ -74,7 +74,7 @@ fn main() {
 
         metrics.sort();
         for metric in metrics {
-            println!("{}", metric);
+            println!("{metric}");
         }
         std::process::exit(0);
     }
@@ -84,7 +84,7 @@ fn main() {
         match PingproxyConfig::load(file) {
             Ok(c) => c,
             Err(e) => {
-                println!("{}", e);
+                println!("{e}");
                 std::process::exit(1);
             }
         }

--- a/src/proxy/thrift/src/main.rs
+++ b/src/proxy/thrift/src/main.rs
@@ -64,7 +64,7 @@ fn main() {
             } else if any.downcast_ref::<Heatmap>().is_some() {
                 for (label, _) in PERCENTILES {
                     let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{:<31} percentile", name));
+                    metrics.push(format!("{name:<31} percentile"));
                 }
             } else {
                 continue;
@@ -73,7 +73,7 @@ fn main() {
 
         metrics.sort();
         for metric in metrics {
-            println!("{}", metric);
+            println!("{metric}");
         }
         std::process::exit(0);
     }
@@ -83,7 +83,7 @@ fn main() {
         match PingproxyConfig::load(file) {
             Ok(c) => c,
             Err(e) => {
-                println!("{}", e);
+                println!("{e}");
                 std::process::exit(1);
             }
         }

--- a/src/server/pingserver/src/main.rs
+++ b/src/server/pingserver/src/main.rs
@@ -24,7 +24,7 @@ use server::PERCENTILES;
 fn main() {
     // custom panic hook to terminate whole process after unwinding
     std::panic::set_hook(Box::new(|s| {
-        eprintln!("{}", s);
+        eprintln!("{s}");
         eprintln!("{:?}", Backtrace::new());
         std::process::exit(101);
     }));
@@ -76,7 +76,7 @@ fn main() {
             } else if any.downcast_ref::<Heatmap>().is_some() {
                 for (label, _) in PERCENTILES {
                     let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{:<31} percentile", name));
+                    metrics.push(format!("{name:<31} percentile"));
                 }
             } else {
                 continue;
@@ -85,7 +85,7 @@ fn main() {
 
         metrics.sort();
         for metric in metrics {
-            println!("{}", metric);
+            println!("{metric}");
         }
         std::process::exit(0);
     }
@@ -108,7 +108,7 @@ fn main() {
     match Pingserver::new(config) {
         Ok(s) => s.wait(),
         Err(e) => {
-            eprintln!("error launching pingserver: {}", e);
+            eprintln!("error launching pingserver: {e}");
             std::process::exit(1);
         }
     }

--- a/src/server/pingserver/tests/integration.rs
+++ b/src/server/pingserver/tests/integration.rs
@@ -37,7 +37,7 @@ fn main() {
 
     // shutdown server and join
     info!("shutdown...");
-    let _ = server.shutdown();
+    server.shutdown();
     info!("passed!");
 }
 
@@ -77,7 +77,7 @@ fn test(name: &str, data: &[(&str, Option<&str>)]) {
         if let Some(response) = response {
             match stream.read(&mut buf) {
                 Err(e) => {
-                    panic!("error reading response: {}", e);
+                    panic!("error reading response: {e}");
                 }
                 Ok(_) => {
                     if response.as_bytes() != &buf[0..response.len()] {

--- a/src/server/segcache/benches/benchmark.rs
+++ b/src/server/segcache/benches/benchmark.rs
@@ -44,9 +44,9 @@ fn get_benchmark(c: &mut Criterion) {
     // benchmark for a few key lengths
     for klen in [1, 16, 64, 255].iter() {
         // benchmark getting empty value
-        let bench_name = format!("get/{}b/0b", klen);
+        let bench_name = format!("get/{klen}b/0b");
         let key = format!("{:01$}", 0, klen);
-        let msg = format!("get {}\r\n", key);
+        let msg = format!("get {key}\r\n");
         group.bench_function(&bench_name, |b| {
             b.iter(|| {
                 assert!(stream.write_all(msg.as_bytes()).is_ok());
@@ -60,9 +60,9 @@ fn get_benchmark(c: &mut Criterion) {
 
         // benchmark across a few value lengths
         for vlen in [1, 64, 1024, 4096].iter() {
-            let key = format!("{:01$}", key_id, klen);
+            let key = format!("{key_id:0klen$}");
             let value = format!("{:A>1$}", 0, vlen);
-            let msg = format!("set {} 0 0 {}\r\n{}\r\n", key, vlen, value);
+            let msg = format!("set {key} 0 0 {vlen}\r\n{value}\r\n");
             assert!(stream.write_all(msg.as_bytes()).is_ok());
             if let Ok(bytes) = stream.read(&mut buffer) {
                 assert_eq!(&buffer[0..bytes], b"STORED\r\n", "invalid response");
@@ -70,9 +70,9 @@ fn get_benchmark(c: &mut Criterion) {
                 panic!("read error");
             }
 
-            let bench_name = format!("get/{}b/{}b", klen, vlen);
-            let msg = format!("get {}\r\n", key);
-            let response = format!("VALUE {} 0 {}\r\n{}\r\nEND\r\n", key, vlen, value);
+            let bench_name = format!("get/{klen}b/{vlen}b");
+            let msg = format!("get {key}\r\n");
+            let response = format!("VALUE {key} 0 {vlen}\r\n{value}\r\nEND\r\n");
             group.bench_function(&bench_name, |b| {
                 b.iter(|| {
                     assert!(stream.write_all(msg.as_bytes()).is_ok());

--- a/src/server/segcache/src/main.rs
+++ b/src/server/segcache/src/main.rs
@@ -28,7 +28,7 @@ use server::PERCENTILES;
 fn main() {
     // custom panic hook to terminate whole process after unwinding
     std::panic::set_hook(Box::new(|s| {
-        eprintln!("{}", s);
+        eprintln!("{s}");
         eprintln!("{:?}", Backtrace::new());
         std::process::exit(101);
     }));
@@ -85,7 +85,7 @@ fn main() {
             } else if any.downcast_ref::<Heatmap>().is_some() {
                 for (label, _) in PERCENTILES {
                     let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{:<31} percentile", name));
+                    metrics.push(format!("{name:<31} percentile"));
                 }
             } else {
                 continue;
@@ -94,7 +94,7 @@ fn main() {
 
         metrics.sort();
         for metric in metrics {
-            println!("{}", metric);
+            println!("{metric}");
         }
         std::process::exit(0);
     }
@@ -122,7 +122,7 @@ fn main() {
     match Segcache::new(config) {
         Ok(segcache) => segcache.wait(),
         Err(e) => {
-            eprintln!("error launching segcache: {}", e);
+            eprintln!("error launching segcache: {e}");
             std::process::exit(1);
         }
     }

--- a/src/server/segcache/tests/integration.rs
+++ b/src/server/segcache/tests/integration.rs
@@ -31,7 +31,7 @@ fn main() {
 
     // shutdown server and join
     info!("shutdown...");
-    let _ = server.shutdown();
+    server.shutdown();
 
     info!("passed!");
 }

--- a/src/server/segcache/tests/integration_multi.rs
+++ b/src/server/segcache/tests/integration_multi.rs
@@ -33,7 +33,7 @@ fn main() {
 
     // shutdown server and join
     info!("shutdown...");
-    let _ = server.shutdown();
+    server.shutdown();
 
     info!("passed!");
 }

--- a/src/storage/seg/benches/benchmark.rs
+++ b/src/storage/seg/benches/benchmark.rs
@@ -34,7 +34,7 @@ fn get_benchmark(c: &mut Criterion) {
 
         let mut key = 0;
 
-        group.bench_function(&format!("{}b/0b", key_size), |b| {
+        group.bench_function(&format!("{key_size}b/0b"), |b| {
             b.iter(|| {
                 cache.get(&keys[key]);
                 key += 1;
@@ -92,7 +92,7 @@ fn set_benchmark(c: &mut Criterion) {
             let mut key = 0;
             let mut value = 0;
 
-            group.bench_function(&format!("{}b/{}b", key_size, value_size), |b| {
+            group.bench_function(&format!("{key_size}b/{value_size}b"), |b| {
                 b.iter(|| {
                     let _ = cache.insert(&keys[key], &values[value], None, ttl);
                     key += 1;

--- a/src/storage/seg/src/hashtable/mod.rs
+++ b/src/storage/seg/src/hashtable/mod.rs
@@ -486,9 +486,9 @@ impl HashTable {
     ///
     /// A failure indicates that the CAS value did not match or there was no
     /// matching item for that key.
-    pub fn try_update_cas<'a>(
+    pub fn try_update_cas(
         &mut self,
-        key: &'a [u8],
+        key: &[u8],
         cas: u32,
         segments: &mut Segments,
     ) -> Result<(), SegError> {

--- a/src/storage/seg/src/segments/segments.rs
+++ b/src/storage/seg/src/segments/segments.rs
@@ -594,7 +594,7 @@ impl Segments {
         for id in 1..=self.cap {
             // this is safe because we start iterating from 1
             let segment = self
-                .get_mut(unsafe { NonZeroU32::new_unchecked(id as u32) })
+                .get_mut(unsafe { NonZeroU32::new_unchecked(id) })
                 .unwrap();
             segment.check_magic();
             let count = segment.live_items();

--- a/src/storage/seg/src/tests.rs
+++ b/src/storage/seg/src/tests.rs
@@ -76,7 +76,7 @@ fn get() {
     assert!(cache.get(b"coffee").is_some());
 
     let item = cache.get(b"coffee").unwrap();
-    assert_eq!(item.value(), b"strong", "item is: {:?}", item);
+    assert_eq!(item.value(), b"strong", "item is: {item:?}");
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn overwrite() {
     assert!(item.is_some());
     let item = item.unwrap();
     let value = item.value();
-    assert_eq!(value, b"coffee", "item is: {:?}", item);
+    assert_eq!(value, b"coffee", "item is: {item:?}");
 
     println!("==== second insert ====");
     assert!(cache.insert(b"drink", b"espresso", None, ttl).is_ok());
@@ -141,7 +141,7 @@ fn overwrite() {
     assert!(item.is_some());
     let item = item.unwrap();
     let value = item.value();
-    assert_eq!(value, b"espresso", "item is: {:?}", item);
+    assert_eq!(value, b"espresso", "item is: {item:?}");
 
     println!("==== third insert ====");
     assert!(cache.insert(b"drink", b"whisky", None, ttl).is_ok());
@@ -151,7 +151,7 @@ fn overwrite() {
     assert!(item.is_some());
     let item = item.unwrap();
     let value = item.value();
-    assert_eq!(value, b"whisky", "item is: {:?}", item);
+    assert_eq!(value, b"whisky", "item is: {item:?}");
 }
 
 #[test]
@@ -177,9 +177,9 @@ fn delete() {
     assert!(item.is_some());
     let item = item.unwrap();
     let value = item.value();
-    assert_eq!(value, b"coffee", "item is: {:?}", item);
+    assert_eq!(value, b"coffee", "item is: {item:?}");
 
-    assert_eq!(cache.delete(b"drink"), true);
+    assert!(cache.delete(b"drink"));
     assert_eq!(cache.segments.free(), 63);
     assert_eq!(cache.items(), 0);
 }
@@ -205,7 +205,7 @@ fn collisions_2() {
     // collision on the 8th insert.
     for i in 0..1000 {
         let i = i % 3;
-        let v = format!("{:02}", i);
+        let v = format!("{i:02}");
         assert!(cache.insert(v.as_bytes(), v.as_bytes(), None, ttl).is_ok());
         let item = cache.get(v.as_bytes());
         assert!(item.is_some());
@@ -232,7 +232,7 @@ fn collisions() {
     // has 7 slots. since we don't support chaining, we must have a
     // collision on the 8th insert.
     for i in 0..7 {
-        let v = format!("{}", i);
+        let v = format!("{i}");
         assert!(cache.insert(v.as_bytes(), v.as_bytes(), None, ttl).is_ok());
         let item = cache.get(v.as_bytes());
         assert!(item.is_some());
@@ -241,7 +241,7 @@ fn collisions() {
     let v = b"8";
     assert!(cache.insert(v, v, None, ttl).is_err());
     assert_eq!(cache.items(), 7);
-    assert_eq!(cache.delete(b"0"), true);
+    assert!(cache.delete(b"0"));
     assert_eq!(cache.items(), 6);
     assert!(cache.insert(v, v, None, ttl).is_ok());
     assert_eq!(cache.items(), 7);
@@ -401,7 +401,7 @@ fn clear() {
     assert!(cache.get(b"coffee").is_some());
 
     let item = cache.get(b"coffee").unwrap();
-    assert_eq!(item.value(), b"strong", "item is: {:?}", item);
+    assert_eq!(item.value(), b"strong", "item is: {item:?}");
 
     cache.clear();
     assert_eq!(cache.segments.free(), segments);
@@ -429,23 +429,23 @@ fn wrapping_add() {
     assert!(cache.get(b"coffee").is_some());
 
     let item = cache.get(b"coffee").unwrap();
-    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    assert_eq!(item.value(), 0, "item is: {item:?}");
     cache
         .wrapping_add(b"coffee", 1)
         .expect("failed to increment");
-    assert_eq!(item.value(), 1, "item is: {:?}", item);
+    assert_eq!(item.value(), 1, "item is: {item:?}");
     cache
         .wrapping_add(b"coffee", u64::MAX - 1)
         .expect("failed to increment");
-    assert_eq!(item.value(), u64::MAX, "item is: {:?}", item);
+    assert_eq!(item.value(), u64::MAX, "item is: {item:?}");
     cache
         .wrapping_add(b"coffee", 1)
         .expect("failed to increment");
-    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    assert_eq!(item.value(), 0, "item is: {item:?}");
     cache
         .wrapping_add(b"coffee", 2)
         .expect("failed to increment");
-    assert_eq!(item.value(), 2, "item is: {:?}", item);
+    assert_eq!(item.value(), 2, "item is: {item:?}");
 }
 
 #[test]
@@ -468,19 +468,19 @@ fn saturating_sub() {
     assert!(cache.get(b"coffee").is_some());
 
     let item = cache.get(b"coffee").unwrap();
-    assert_eq!(item.value(), 3, "item is: {:?}", item);
+    assert_eq!(item.value(), 3, "item is: {item:?}");
     cache
         .saturating_sub(b"coffee", 2)
         .expect("failed to increment");
-    assert_eq!(item.value(), 1, "item is: {:?}", item);
+    assert_eq!(item.value(), 1, "item is: {item:?}");
     cache
         .saturating_sub(b"coffee", 1)
         .expect("failed to increment");
-    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    assert_eq!(item.value(), 0, "item is: {item:?}");
     cache
         .saturating_sub(b"coffee", 1)
         .expect("failed to increment");
-    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    assert_eq!(item.value(), 0, "item is: {item:?}");
 }
 
 #[test]

--- a/src/storage/seg/src/ttl_buckets/tests.rs
+++ b/src/storage/seg/src/ttl_buckets/tests.rs
@@ -26,14 +26,12 @@ fn bucket_index() {
         assert_eq!(
             ttl_buckets.get_bucket_index(start) as u32,
             bucket,
-            "ttl: {:?}",
-            start
+            "ttl: {start:?}"
         );
         assert_eq!(
             ttl_buckets.get_bucket_index(end) as u32,
             bucket,
-            "ttl: {:?}",
-            end
+            "ttl: {end:?}"
         );
     }
 
@@ -44,14 +42,12 @@ fn bucket_index() {
         assert_eq!(
             ttl_buckets.get_bucket_index(start) as u32,
             bucket + 256,
-            "ttl: {:?}",
-            start
+            "ttl: {start:?}"
         );
         assert_eq!(
             ttl_buckets.get_bucket_index(end) as u32,
             bucket + 256,
-            "ttl: {:?}",
-            end
+            "ttl: {end:?}"
         );
     }
 
@@ -62,14 +58,12 @@ fn bucket_index() {
         assert_eq!(
             ttl_buckets.get_bucket_index(start) as u32,
             bucket + 512,
-            "ttl: {:?}",
-            start
+            "ttl: {start:?}"
         );
         assert_eq!(
             ttl_buckets.get_bucket_index(end) as u32,
             bucket + 512,
-            "ttl: {:?}",
-            end
+            "ttl: {end:?}"
         );
     }
 
@@ -80,14 +74,12 @@ fn bucket_index() {
         assert_eq!(
             ttl_buckets.get_bucket_index(start) as u32,
             bucket + 768,
-            "ttl: {:?}",
-            start
+            "ttl: {start:?}"
         );
         assert_eq!(
             ttl_buckets.get_bucket_index(end) as u32,
             bucket + 768,
-            "ttl: {:?}",
-            end
+            "ttl: {end:?}"
         );
     }
 

--- a/src/storage/types/src/lib.rs
+++ b/src/storage/types/src/lib.rs
@@ -111,8 +111,8 @@ impl<'a> PartialEq<u64> for Value<'a> {
 impl<'a> core::fmt::Debug for Value<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         match &self {
-            Value::Bytes(v) => write!(f, "{:?}", v),
-            Value::U64(v) => write!(f, "{}", v),
+            Value::Bytes(v) => write!(f, "{v:?}"),
+            Value::U64(v) => write!(f, "{v}"),
         }
     }
 }


### PR DESCRIPTION
As in the title. Recent updates to the clippy lints have added a bunch of warn-by-default lints that need to be fixed to make CI happy.