### PR TITLE
chore: Add check-success jobs to end of CI workflows

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -278,3 +278,24 @@ jobs:
           tls: false   
       - name: Validate
         run: sleep 60 && curl -s http://localhost:9998/vars.json | jq '.' > /dev/null
+
+  check-success:
+    name: verify all tests pass
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - bench-check
+      - check
+      - rustfmt
+      - clippy
+      - audit
+      - smoketest-pingserver
+      - smoketest-pingserver-tls
+      - smoketest-pingproxy
+      - smoketest-pingproxy-tls-terminating
+      - smoketest-exposition
+
+    steps:
+      - name: no-op
+        run: |
+          echo "All checks passed!"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -47,3 +47,14 @@ jobs:
             cargo +nightly fuzz run ${FUZZ_TARGET} --jobs ${{ env.FUZZ_JOBS }} -- \
               -max_total_time=${{ env.FUZZ_TIME }};
           done
+
+  check-success:
+    name: verify all tests pass
+    runs-on: ubuntu-latest
+    needs:
+      - build
+
+    steps:
+      - name: no-op
+        run: |
+          echo "All checks passed!"


### PR DESCRIPTION
These are meant to be used for branch protection rules so that we don't end up having to add everything in the test matrix to them.