### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/src/entrystore/src/seg/resp.rs
+++ b/src/entrystore/src/seg/resp.rs
@@ -27,7 +27,7 @@ impl Storage for Seg {
         if let Some(item) = self.data.get(get.key()) {
             match item.value() {
                 seg::Value::Bytes(b) => Response::bulk_string(b),
-                seg::Value::U64(v) => Response::bulk_string(format!("{}", v).as_bytes()),
+                seg::Value::U64(v) => Response::bulk_string(format!("{v}").as_bytes()),
             }
         } else {
             Response::null()

--- a/src/protocol/resp/src/request/mod.rs
+++ b/src/protocol/resp/src/request/mod.rs
@@ -322,10 +322,10 @@ impl Default for ExpireTime {
 impl Display for ExpireTime {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExpireTime::Seconds(s) => write!(f, "{}s", s),
-            ExpireTime::Milliseconds(ms) => write!(f, "{}ms", ms),
-            ExpireTime::UnixSeconds(s) => write!(f, "{}unix_secs", s),
-            ExpireTime::UnixMilliseconds(ms) => write!(f, "{}unix_ms", ms),
+            ExpireTime::Seconds(s) => write!(f, "{s}s"),
+            ExpireTime::Milliseconds(ms) => write!(f, "{ms}ms"),
+            ExpireTime::UnixSeconds(s) => write!(f, "{s}unix_secs"),
+            ExpireTime::UnixMilliseconds(ms) => write!(f, "{ms}unix_ms"),
             ExpireTime::KeepTtl => write!(f, "keep_ttl"),
         }
     }

--- a/src/protocol/resp/src/request/sdiff.rs
+++ b/src/protocol/resp/src/request/sdiff.rs
@@ -59,7 +59,7 @@ impl From<&SetDiff> for Message {
     fn from(value: &SetDiff) -> Self {
         let mut vals = Vec::with_capacity(value.keys().len() + 1);
         vals.push(Message::bulk_string(b"SDIFF"));
-        vals.extend(value.keys().iter().map(|v| Message::bulk_string(&v)));
+        vals.extend(value.keys().iter().map(|v| Message::bulk_string(v)));
 
         Message::Array(Array { inner: Some(vals) })
     }

--- a/src/protocol/resp/src/request/set.rs
+++ b/src/protocol/resp/src/request/set.rs
@@ -21,7 +21,7 @@ impl Display for SetMode {
             SetMode::Replace => "replace",
             SetMode::Set => "set",
         };
-        write!(f, "{}", string)
+        write!(f, "{string}")
     }
 }
 

--- a/src/protocol/resp/src/request/sinter.rs
+++ b/src/protocol/resp/src/request/sinter.rs
@@ -59,7 +59,7 @@ impl From<&SetIntersect> for Message {
     fn from(value: &SetIntersect) -> Self {
         let mut vals = Vec::with_capacity(value.keys().len() + 1);
         vals.push(Message::bulk_string(b"SINTER"));
-        vals.extend(value.keys().iter().map(|v| Message::bulk_string(&v)));
+        vals.extend(value.keys().iter().map(|v| Message::bulk_string(v)));
 
         Message::Array(Array { inner: Some(vals) })
     }

--- a/src/protocol/resp/src/request/sunion.rs
+++ b/src/protocol/resp/src/request/sunion.rs
@@ -59,7 +59,7 @@ impl From<&SetUnion> for Message {
     fn from(value: &SetUnion) -> Self {
         let mut vals = Vec::with_capacity(value.keys().len() + 1);
         vals.push(Message::bulk_string(b"SUNION"));
-        vals.extend(value.keys().iter().map(|v| Message::bulk_string(&v)));
+        vals.extend(value.keys().iter().map(|v| Message::bulk_string(v)));
 
         Message::Array(Array { inner: Some(vals) })
     }

--- a/src/proxy/momento/src/frontend.rs
+++ b/src/proxy/momento/src/frontend.rs
@@ -159,13 +159,13 @@ pub(crate) async fn handle_resp_client(
                     resp::rpop(&mut client, &cache_name, &mut response_buf, r).await?
                 }
                 resp::Request::Set(r) => {
-                    resp::set(&mut client, &cache_name, &mut socket, &r).await?
+                    resp::set(&mut client, &cache_name, &mut socket, r).await?
                 }
                 resp::Request::SetAdd(r) => {
-                    resp::sadd(&mut client, &cache_name, &mut socket, &r).await?
+                    resp::sadd(&mut client, &cache_name, &mut socket, r).await?
                 }
                 resp::Request::SetRem(r) => {
-                    resp::srem(&mut client, &cache_name, &mut socket, &r).await?
+                    resp::srem(&mut client, &cache_name, &mut socket, r).await?
                 }
                 resp::Request::SetDiff(r) => {
                     resp::sdiff(&mut client, &cache_name, &mut response_buf, r).await?
@@ -177,7 +177,7 @@ pub(crate) async fn handle_resp_client(
                     resp::sinter(&mut client, &cache_name, &mut response_buf, r).await?
                 }
                 resp::Request::SetMembers(r) => {
-                    resp::smembers(&mut client, &cache_name, &mut response_buf, &r).await?
+                    resp::smembers(&mut client, &cache_name, &mut response_buf, r).await?
                 }
                 resp::Request::SetIsMember(r) => {
                     resp::sismember(&mut client, &cache_name, &mut response_buf, r).await?
@@ -237,7 +237,7 @@ pub(crate) async fn handle_resp_client(
         SESSION_SEND_BYTE.add(response_buf.len() as _);
         TCP_SEND_BYTE.add(response_buf.len() as _);
 
-        if let Err(_) = socket.write_all(&response_buf).await {
+        if socket.write_all(&response_buf).await.is_err() {
             SESSION_SEND_EX.increment();
             break;
         }

--- a/src/proxy/momento/src/protocol/resp/lpop.rs
+++ b/src/proxy/momento/src/protocol/resp/lpop.rs
@@ -55,7 +55,7 @@ pub async fn lpop(
                 }
 
                 // We got no elements, the list does not exist.
-                if items.len() == 0 {
+                if items.is_empty() {
                     response_buf.extend_from_slice(b"*-1\r\n");
                 } else {
                     write!(response_buf, "*{}\r\n", items.len())?;

--- a/src/proxy/momento/src/protocol/resp/rpop.rs
+++ b/src/proxy/momento/src/protocol/resp/rpop.rs
@@ -56,7 +56,7 @@ pub async fn rpop(
                 }
 
                 // We got no elements, the list does not exist.
-                if items.len() == 0 {
+                if items.is_empty() {
                     response_buf.extend_from_slice(b"*-1\r\n");
                 } else {
                     write!(response_buf, "*{}\r\n", items.len())?;

--- a/src/server/rds/benches/benchmark.rs
+++ b/src/server/rds/benches/benchmark.rs
@@ -51,9 +51,9 @@ fn get_benchmark(c: &mut Criterion) {
     // benchmark for a few key lengths
     for klen in [1, 16, 64, 255].iter() {
         // benchmark getting empty value
-        let bench_name = format!("get/{}b/0b", klen);
+        let bench_name = format!("get/{klen}b/0b");
         let key = format!("{:01$}", 0, klen);
-        let msg = format!("get {}\r\n", key);
+        let msg = format!("get {key}\r\n");
         group.bench_function(&bench_name, |b| {
             b.iter(|| {
                 assert!(stream.write_all(msg.as_bytes()).is_ok());
@@ -67,9 +67,9 @@ fn get_benchmark(c: &mut Criterion) {
 
         // benchmark across a few value lengths
         for vlen in [1, 64, 1024, 4096].iter() {
-            let key = format!("{:01$}", key_id, klen);
+            let key = format!("{key_id:0klen$}");
             let value = format!("{:A>1$}", 0, vlen);
-            let msg = format!("set {} {}\r\n", key, value);
+            let msg = format!("set {key} {value}\r\n");
             assert!(stream.write_all(msg.as_bytes()).is_ok());
             if let Ok(bytes) = stream.read(&mut buffer) {
                 assert_eq!(&buffer[0..bytes], RESP_OK, "invalid response");
@@ -77,9 +77,9 @@ fn get_benchmark(c: &mut Criterion) {
                 panic!("read error");
             }
 
-            let bench_name = format!("get/{}b/{}b", klen, vlen);
-            let msg = format!("get {}\r\n", key);
-            let response = format!("${}\r\n{}\r\n", vlen, value);
+            let bench_name = format!("get/{klen}b/{vlen}b");
+            let msg = format!("get {key}\r\n");
+            let response = format!("${vlen}\r\n{value}\r\n");
             group.bench_function(&bench_name, |b| {
                 b.iter(|| {
                     assert!(stream.write_all(msg.as_bytes()).is_ok());

--- a/src/server/rds/src/main.rs
+++ b/src/server/rds/src/main.rs
@@ -28,7 +28,7 @@ use server::PERCENTILES;
 fn main() {
     // custom panic hook to terminate whole process after unwinding
     std::panic::set_hook(Box::new(|s| {
-        eprintln!("{}", s);
+        eprintln!("{s}");
         eprintln!("{:?}", Backtrace::new());
         std::process::exit(101);
     }));
@@ -85,7 +85,7 @@ fn main() {
             } else if any.downcast_ref::<Heatmap>().is_some() {
                 for (label, _) in PERCENTILES {
                     let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{:<31} percentile", name));
+                    metrics.push(format!("{name:<31} percentile"));
                 }
             } else {
                 continue;
@@ -94,7 +94,7 @@ fn main() {
 
         metrics.sort();
         for metric in metrics {
-            println!("{}", metric);
+            println!("{metric}");
         }
         std::process::exit(0);
     }
@@ -122,7 +122,7 @@ fn main() {
     match Rds::new(config) {
         Ok(rds) => rds.wait(),
         Err(e) => {
-            eprintln!("error launching rds: {}", e);
+            eprintln!("error launching rds: {e}");
             std::process::exit(1);
         }
     }

--- a/src/server/rds/tests/common.rs
+++ b/src/server/rds/tests/common.rs
@@ -189,5 +189,5 @@ const RESP_OK: &str = "+OK\r\n";
 
 fn bulk_string(str: &str) -> String {
     let length = str.as_bytes().len();
-    format!("${}\r\n{}\r\n", length, str)
+    format!("${length}\r\n{str}\r\n")
 }

--- a/src/server/rds/tests/integration.rs
+++ b/src/server/rds/tests/integration.rs
@@ -31,7 +31,7 @@ fn main() {
 
     // shutdown server and join
     info!("shutdown...");
-    let _ = server.shutdown();
+    server.shutdown();
 
     info!("passed!");
 }

--- a/src/server/rds/tests/integration_multi.rs
+++ b/src/server/rds/tests/integration_multi.rs
@@ -33,7 +33,7 @@ fn main() {
 
     // shutdown server and join
     info!("shutdown...");
-    let _ = server.shutdown();
+    server.shutdown();
 
     info!("passed!");
 }


### PR DESCRIPTION
We have a bunch of these. All this PR does is run `cargo clippy --fix` over the codebase.