### PR TITLE
chore: Remove CI smoketests

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -140,79 +140,6 @@ jobs:
           name: binaries
           path: install
 
-  smoketest-pingserver:
-    name: ${{ matrix.tls && 'smoketest-pingserver-tls' || 'smoketest-pingserver' }}
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    strategy:
-      matrix:
-        tls: [true, false]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-smoketest
-      - uses: ./.github/actions/ca
-      - uses: ./.github/actions/pingserver
-        with:
-          tls: ${{ matrix.tls }}
-      - uses: ./.github/actions/rpc-perf
-        with:
-          protocol: ping
-          port: 12321
-          tls: ${{ matrix.tls }}
-
-  smoketest-pingproxy:
-    name: smoketest-pingproxy
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-smoketest
-      - uses: ./.github/actions/ca
-      - uses: ./.github/actions/pingserver
-        with:
-          tls: false
-      - uses: ./.github/actions/pingproxy
-        with:
-          tls: false
-      - uses: ./.github/actions/rpc-perf
-        with:
-          protocol: ping
-          port: 12322
-          tls: false
-
-  smoketest-pingproxy-tls-terminating:
-    name: smoketest-pingproxy-tls-terminating
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-smoketest
-      - uses: ./.github/actions/ca
-      - uses: ./.github/actions/pingserver
-        with:
-          tls: false
-      - uses: ./.github/actions/pingproxy
-        with:
-          tls: true
-      - uses: ./.github/actions/rpc-perf
-        with:
-          protocol: ping
-          port: 12322
-          tls: true
-
-  smoketest-exposition:
-    name: smoketest-exposition
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-smoketest
-      - uses: ./.github/actions/pingserver
-        with:
-          tls: false
-      - name: Validate
-        run: curl -s http://localhost:9998/vars.json | jq '.' > /dev/null
-
   check-success:
     name: verify all tests pass
     runs-on: ubuntu-latest
@@ -223,10 +150,6 @@ jobs:
       - clippy
       - clippy-upload
       - audit
-      - smoketest-pingserver
-      - smoketest-pingproxy
-      - smoketest-pingproxy-tls-terminating
-      - smoketest-exposition
 
     steps:
       - name: no-op


### PR DESCRIPTION
These tests don't actually cause errors if they fail so we might as well just remove them.