### PR TITLE
chore: Don't use LLD for CI

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -8,15 +8,3 @@ runs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
-
-    - name: Configure Rustflags
-      shell: bash
-      env:
-        CONFIG: |
-          [target.x86_64-unknown-linux-gnu]
-          rustflags = [ "-C", "link-arg=-fuse-ld=lld" ]
-
-          [target.x86_64-apple-darwin]
-          rustflags = [ "-C", "link-arg=-fuse-ld=lld" ]
-      run: |
-        echo "$CONFIG" >> ~/.cargo/config.toml

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -7,7 +7,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
-  RUSTFLAGS: "--cfg=CI"
 
 jobs:
   # First stage: these are quick jobs that give immediate feedback on a PR.


### PR DESCRIPTION
Turns out this actually doesn't work but was masked because we were setting `RUSTFLAGS` via an environment variable in the jobs.