### PR TITLE
fix: install `protobuf-compiler` before using it in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ COPY . .
 RUN apt-get update && apt-get install -y \
   cmake \
   clang \
-  protobuf-compiler
+  protobuf-compiler \
+  && rm -rf /var/lib/apt/lists/*
 RUN cargo vendor > .cargo/config
 
 RUN cargo build --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@
 FROM rust:latest as cargo-build
 
 COPY . .
-RUN apt-get update
-RUN apt-get install -y cmake
-RUN apt-get install -y clang
+RUN apt-get update && apt-get install -y \
+  cmake \
+  clang \
+  protobuf-compiler
 RUN cargo vendor > .cargo/config
 
-RUN  apt-get install -y protobuf-compiler
 RUN cargo build --release
 
 # -----------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get install -y cmake
 RUN apt-get install -y clang
 RUN cargo vendor > .cargo/config
 
+RUN  apt-get install -y protobuf-compiler
 RUN cargo build --release
 
 # -----------------


### PR DESCRIPTION
Fix #75 

Before I added this line, the Docker image failed to build. After I added it, I get a built docker image

I also changed the `apt-get update` and subsequent `apt-get install` to be a single-line docker statement in https://github.com/pelikan-io/pelikan/pull/76/commits/f8e090960fca6b4775f6b28d50820bda90eebc7a

This has a performance benefit by minimizing the number of layers as well as forcing `apt-get update` to be run again uncached if the list of packages to be installed changes (reference [1 ](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)and [2](https://stackoverflow.com/questions/56329971/putting-run-commands-in-one-line-make-build-faster))

