### PR TITLE
chore: add .dockerignore to speed up local builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+target


### PR DESCRIPTION
This shouldn't improve anything in a CI-context i.e. any time you're cloning the repository fresh and running docker commands inside.

However, with local development, we are currently sending all of `target` in the Docker "build context" which, on my machine is 18GB and dramatically slows down the Docker build loop.