### PR TITLE
chore: only build momento_proxy in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y cmake
 RUN apt-get install -y clang
 RUN cargo vendor > .cargo/config
 
-RUN cargo build --release
+RUN cargo build --release  -p momento_proxy
 
 # -----------------
 # Run Momento Proxy


### PR DESCRIPTION
If we are only running the release binary of `momento_proxy` in this `Dockerfile` then we can speed up the docker build by only building that one package