### PR TITLE
Use an alternate install action to install cargo-audit

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           shared-key: check-ubuntu-latest
           save-if: false
-      - uses: baptiste0928/cargo-install
+      - uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-audit
           locked: true

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-audit
-          locked: true
+          args: --locked
       - run: |
           cargo audit
         

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -70,9 +70,10 @@ jobs:
         with:
           shared-key: check-ubuntu-latest
           save-if: false
-      - uses: taiki-e/install-action@v2
+      - uses: baptiste0928/cargo-install
         with:
-          tool: cargo-audit
+          crate: cargo-audit
+          locked: true
       - run: |
           cargo audit
         


### PR DESCRIPTION
The existing one keeps running into 429 errors. This PR takes a different approach and just caches the built binary.