### PR TITLE
fix: properly feature gate ping protocol stats

### DIFF
--- a/src/protocol/ping/Cargo.toml
+++ b/src/protocol/ping/Cargo.toml
@@ -26,5 +26,6 @@ criterion = "0.3.4"
 
 [features]
 default = []
-client = []
-server = []
+client = ["stats"]
+server = ["stats"]
+stats = []

--- a/src/protocol/ping/src/lib.rs
+++ b/src/protocol/ping/src/lib.rs
@@ -18,4 +18,18 @@ mod ping;
 
 pub use ping::*;
 
+#[cfg(feature = "stats")]
+use stats::*;
+
+#[cfg(feature = "stats")]
+mod stats {
+    use metriken::*;
+
+    #[cfg(feature = "server")]
+    counter!(PING, "the number of ping requests");
+
+    #[cfg(feature = "client")]
+    counter!(PONG, "the number of pong responses");
+}
+
 common::metrics::test_no_duplicates!();

--- a/src/protocol/ping/src/ping/wire/mod.rs
+++ b/src/protocol/ping/src/ping/wire/mod.rs
@@ -9,9 +9,3 @@ mod response;
 
 pub use request::*;
 pub use response::*;
-
-#[allow(unused)]
-use metriken::*;
-
-counter!(PING);
-counter!(PONG);


### PR DESCRIPTION
Changes the ping protocol stats to properly feature gate them. Previously, the stats were being registered even when the client and/or server features were not selected.