### PR TITLE
feat: prepare datatier for publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,11 +736,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "datapool"
-version = "0.3.1"
+name = "datatier"
+version = "0.1.0"
 dependencies = [
  "blake3",
- "common",
+ "clocksource",
  "libc",
  "memmap2",
  "tempfile",
@@ -1847,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2304,15 +2304,14 @@ name = "seg"
 version = "0.3.1"
 dependencies = [
  "ahash",
- "common",
+ "clocksource",
  "criterion 0.3.6",
- "datapool",
- "logger",
- "memmap2",
+ "datatier",
  "metriken",
  "rand",
  "rand_chacha",
  "rand_xoshiro",
+ "ringlog",
  "storage-types",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
     "src/server/segcache",
     "src/session",
     "src/storage/bloom",
-    "src/storage/datapool",
+    "src/storage/datatier",
     "src/storage/seg",
     "src/storage/types",
 ]

--- a/src/storage/datatier/Cargo.toml
+++ b/src/storage/datatier/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "datapool"
+name = "datatier"
+version = "0.1.0"
 description = "abstractions for byte storage pools"
 authors = ["Brian Martin <brian@pelikan.io>"]
 
-version = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
@@ -11,7 +11,7 @@ license = { workspace = true }
 
 [dependencies]
 blake3 = { workspace = true }
-common = { path = "../../common" }
+clocksource = { workspace = true }
 libc = { workspace = true }
 memmap2 = { workspace = true }
 

--- a/src/storage/datatier/src/lib.rs
+++ b/src/storage/datatier/src/lib.rs
@@ -3,7 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use blake3::Hash;
-use common::time::{Instant, Nanoseconds, Seconds, UnixInstant};
+use clocksource::{Instant, Nanoseconds, Seconds, UnixInstant};
 use core::ops::Range;
 use std::fs::{File, OpenOptions};
 use std::io::{Error, ErrorKind, Read, Seek, SeekFrom, Write};

--- a/src/storage/seg/Cargo.toml
+++ b/src/storage/seg/Cargo.toml
@@ -27,14 +27,13 @@ default = []
 
 [dependencies]
 ahash = { workspace = true }
-common = { path = "../../common" }
-datapool = { path = "../datapool" }
-logger = { path = "../../logger" }
-memmap2 = { workspace = true }
+clocksource = { workspace = true }
+datatier = { path = "../datatier" }
 metriken = { workspace = true }
 rand = { workspace = true , features = ["small_rng", "getrandom"] }
 rand_chacha = { workspace = true }
 rand_xoshiro = { workspace = true }
+ringlog = { workspace = true }
 storage-types = { path = "../types" }
 thiserror = { workspace = true }
 

--- a/src/storage/seg/src/builder.rs
+++ b/src/storage/seg/src/builder.rs
@@ -167,7 +167,7 @@ impl Builder {
             hashtable,
             segments,
             ttl_buckets,
-            time: Instant::recent(),
+            time: Instant::now(),
         })
     }
 }

--- a/src/storage/seg/src/eviction/mod.rs
+++ b/src/storage/seg/src/eviction/mod.rs
@@ -70,7 +70,7 @@ impl Eviction {
     }
 
     pub fn should_rerank(&mut self) -> bool {
-        let now = Instant::recent();
+        let now = Instant::now();
         match self.policy {
             Policy::None | Policy::Random | Policy::RandomFifo | Policy::Merge { .. } => false,
             Policy::Fifo | Policy::Cte | Policy::Util => {

--- a/src/storage/seg/src/lib.rs
+++ b/src/storage/seg/src/lib.rs
@@ -24,10 +24,10 @@
 
 // macro includes
 #[macro_use]
-extern crate logger;
+extern crate ringlog;
 
 // external crate includes
-use common::time::Seconds;
+use clocksource::Seconds;
 
 // includes from core/std
 use core::hash::{BuildHasher, Hasher};
@@ -64,8 +64,8 @@ pub use item::Item;
 pub use storage_types::Value;
 
 // type aliases
-pub(crate) type Duration = common::time::Duration<Seconds<u32>>;
-pub(crate) type Instant = common::time::Instant<Seconds<u32>>;
+pub(crate) type Duration = clocksource::Duration<Seconds<u32>>;
+pub(crate) type Instant = clocksource::Instant<Seconds<u32>>;
 
 // items from submodules which are imported for convenience to the crate level
 pub(crate) use crate::rand::*;
@@ -74,5 +74,3 @@ pub(crate) use item::*;
 pub(crate) use metrics::*;
 pub(crate) use segments::*;
 pub(crate) use ttl_buckets::*;
-
-common::metrics::test_no_duplicates!();

--- a/src/storage/seg/src/seg.rs
+++ b/src/storage/seg/src/seg.rs
@@ -278,15 +278,13 @@ impl Seg {
     /// assert!(cache.get(b"coffee").is_none());
     /// ```
     pub fn expire(&mut self) -> usize {
-        common::time::refresh_clock();
-        self.time = Instant::recent();
+        self.time = Instant::now();
         self.ttl_buckets
             .expire(&mut self.hashtable, &mut self.segments)
     }
 
     pub fn clear(&mut self) -> usize {
-        common::time::refresh_clock();
-        self.time = Instant::recent();
+        self.time = Instant::now();
         self.ttl_buckets
             .clear(&mut self.hashtable, &mut self.segments)
     }

--- a/src/storage/seg/src/segments/header.rs
+++ b/src/storage/seg/src/segments/header.rs
@@ -268,10 +268,6 @@ impl SegmentHeader {
     }
 
     #[inline]
-    // clippy throws a false positive for suspicious_operation_groupings lint
-    // for the instant + duration portion. We set the allow pragma to silence
-    // the false positive.
-    // #[allow(clippy::suspicious_operation_groupings)]
     /// Can the segment be evicted?
     pub fn can_evict(&self) -> bool {
         self.evictable()

--- a/src/storage/seg/src/segments/header.rs
+++ b/src/storage/seg/src/segments/header.rs
@@ -65,6 +65,7 @@ pub struct SegmentHeader {
 
 impl SegmentHeader {
     pub fn new(id: NonZeroU32) -> Self {
+        let now = Instant::now();
         Self {
             id,
             write_offset: 0,
@@ -72,9 +73,9 @@ impl SegmentHeader {
             live_items: 0,
             prev_seg: None,
             next_seg: None,
-            create_at: Instant::recent(),
+            create_at: now,
             ttl: 0,
-            merge_at: Instant::recent(),
+            merge_at: now,
             accessible: false,
             evictable: false,
             _pad: [0; 25],
@@ -88,13 +89,15 @@ impl SegmentHeader {
         assert!(!self.accessible());
         assert!(!self.evictable());
 
+        let now = Instant::now();
+
         self.reset();
 
         self.prev_seg = None;
         self.next_seg = None;
         self.live_items = 0;
-        self.create_at = Instant::recent();
-        self.merge_at = Instant::recent();
+        self.create_at = now;
+        self.merge_at = now;
         self.accessible = true;
     }
 
@@ -249,7 +252,7 @@ impl SegmentHeader {
     #[inline]
     /// Update the created time
     pub fn mark_created(&mut self) {
-        self.create_at = Instant::recent();
+        self.create_at = Instant::now();
     }
 
     #[inline]
@@ -261,18 +264,18 @@ impl SegmentHeader {
     #[inline]
     /// Update the created time
     pub fn mark_merged(&mut self) {
-        self.merge_at = Instant::recent();
+        self.merge_at = Instant::now();
     }
 
     #[inline]
     // clippy throws a false positive for suspicious_operation_groupings lint
     // for the instant + duration portion. We set the allow pragma to silence
     // the false positive.
-    #[allow(clippy::suspicious_operation_groupings)]
+    // #[allow(clippy::suspicious_operation_groupings)]
     /// Can the segment be evicted?
     pub fn can_evict(&self) -> bool {
         self.evictable()
             && self.next_seg().is_some()
-            && (self.create_at() + self.ttl()) >= (Instant::recent() + SEG_MATURE_TIME)
+            && (self.create_at() + self.ttl()) >= (Instant::now() + SEG_MATURE_TIME)
     }
 }

--- a/src/storage/seg/src/segments/segments.rs
+++ b/src/storage/seg/src/segments/segments.rs
@@ -6,7 +6,7 @@ use crate::eviction::*;
 use crate::item::*;
 use crate::segments::*;
 use core::num::NonZeroU32;
-use datapool::*;
+use datatier::*;
 
 /// `Segments` contain all items within the cache. This struct is a collection
 /// of individual `Segment`s which are represented by a `SegmentHeader` and a
@@ -419,7 +419,6 @@ impl Segments {
                 self.headers[id_idx].write_offset()
             );
 
-            common::time::refresh_clock();
             self.headers[id_idx].mark_created();
             self.headers[id_idx].mark_merged();
 
@@ -558,7 +557,7 @@ impl Segments {
                 // reduces CPU load under heavy rewrite/delete workloads at the
                 // cost of letting more dead items remain in the segements,
                 // reducing the hitrate
-                // if self.headers[seg_id as usize].merge_at() + CoarseDuration::from_secs(30) > CoarseInstant::recent() {
+                // if self.headers[seg_id as usize].merge_at() + CoarseDuration::from_secs(30) > CoarseInstant::now() {
                 //     return Ok(());
                 // }
 

--- a/src/storage/seg/src/ttl_buckets/ttl_bucket.rs
+++ b/src/storage/seg/src/ttl_buckets/ttl_bucket.rs
@@ -84,7 +84,7 @@ impl TtlBucket {
         }
 
         let mut expired = 0;
-        let ts = Instant::recent();
+        let ts = Instant::now();
 
         loop {
             let seg_id = self.head;


### PR DESCRIPTION
Rename the `datapool` crate to `datatier` and prepare to publish.

Reduce the un-published dependencies of the `seg` crate. Remove usage of `recent()` times in favor of `now()`.