### PR TITLE
feat: provide access to resp string message content

### DIFF
--- a/src/protocol/resp/src/lib.rs
+++ b/src/protocol/resp/src/lib.rs
@@ -13,6 +13,8 @@ mod util;
 
 pub mod parse;
 
+pub use protocol_common::*;
+
 pub(crate) use crate::util::*;
 
 pub use crate::request::*;

--- a/src/protocol/resp/src/message/bulk_string.rs
+++ b/src/protocol/resp/src/message/bulk_string.rs
@@ -26,6 +26,10 @@ impl BulkString {
     pub fn null() -> Self {
         Self { inner: None }
     }
+
+    pub fn bytes(&self) -> Option<&[u8]> {
+        self.inner.as_ref().map(|v| v.as_ref())
+    }
 }
 
 impl From<Arc<[u8]>> for BulkString {

--- a/src/protocol/resp/src/message/simple_string.rs
+++ b/src/protocol/resp/src/message/simple_string.rs
@@ -9,11 +9,18 @@ pub struct SimpleString {
     pub(crate) inner: String,
 }
 
+impl AsRef<str> for SimpleString {
+    fn as_ref(&self) -> &str {
+        &self.inner
+    }
+}
+
 impl SimpleString {
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 }
+
 impl Compose for SimpleString {
     fn compose(&self, buf: &mut dyn BufMut) -> usize {
         buf.put_slice(b"+");


### PR DESCRIPTION
Provides access to the contents of bulk and simple string messgaes.

Adds re-export of `Compose` and `Parse` traits for convenience.