### PR TITLE
fix: resp protocol bug for array message compose

### DIFF
--- a/src/protocol/resp/src/message/array.rs
+++ b/src/protocol/resp/src/message/array.rs
@@ -84,11 +84,19 @@ mod tests {
 
     #[test]
     fn parse() {
-        assert_eq!(message(b"*-1\r\n"), Ok((&b""[..], Message::Array(Array::null()),)));
+        assert_eq!(
+            message(b"*-1\r\n"),
+            Ok((&b""[..], Message::Array(Array::null()),))
+        );
 
         assert_eq!(
             message(b"*1\r\n$5\r\nHELLO\r\n"),
-            Ok((&b""[..], Message::Array(Array { inner: Some(vec![Message::bulk_string(b"HELLO")])})))
+            Ok((
+                &b""[..],
+                Message::Array(Array {
+                    inner: Some(vec![Message::bulk_string(b"HELLO")])
+                })
+            ))
         );
     }
 }

--- a/src/protocol/resp/src/message/array.rs
+++ b/src/protocol/resp/src/message/array.rs
@@ -23,7 +23,7 @@ impl Compose for Array {
     fn compose(&self, session: &mut dyn BufMut) -> usize {
         let mut len = 0;
         if let Some(values) = &self.inner {
-            let header = format!("${}\r\n", values.len());
+            let header = format!("*{}\r\n", values.len());
             session.put_slice(header.as_bytes());
             len += header.as_bytes().len();
             for value in values {
@@ -84,21 +84,11 @@ mod tests {
 
     #[test]
     fn parse() {
-        assert_eq!(message(b"$-1\r\n"), Ok((&b""[..], Message::null(),)));
+        assert_eq!(message(b"*-1\r\n"), Ok((&b""[..], Message::Array(Array::null()),)));
 
         assert_eq!(
-            message(b"$0\r\n\r\n"),
-            Ok((&b""[..], Message::bulk_string(&[])))
-        );
-
-        assert_eq!(
-            message(b"$1\r\n\0\r\n"),
-            Ok((&b""[..], Message::bulk_string(&[0])))
-        );
-
-        assert_eq!(
-            message(b"$11\r\nHELLO WORLD\r\n"),
-            Ok((&b""[..], Message::bulk_string("HELLO WORLD".as_bytes())))
+            message(b"*1\r\n$5\r\nHELLO\r\n"),
+            Ok((&b""[..], Message::Array(Array { inner: Some(vec![Message::bulk_string(b"HELLO")])})))
         );
     }
 }


### PR DESCRIPTION
Fixes a bug in the resp protocol implementation for composing array messages into the wire format. Fixes the incorrect prefix character for non-null array messages and ensures correct unit tests are present and passing.