### PR TITLE
feat: add len for array messages in resp protocol

### DIFF
--- a/src/protocol/resp/src/message/array.rs
+++ b/src/protocol/resp/src/message/array.rs
@@ -17,6 +17,12 @@ impl Array {
     pub fn null() -> Self {
         Self { inner: None }
     }
+
+    /// Get the number of items in the array. The `None` variant indicates a
+    /// null array.
+    pub fn len(&self) -> Option<usize> {
+        self.inner.as_ref().map(|a| a.len())
+    }
 }
 
 impl Compose for Array {


### PR DESCRIPTION
Adds a `len` function for array message types in the resp protocol.