### PR TITLE
feat: export TimeType in memcache protocol

### DIFF
--- a/src/protocol/memcache/src/lib.rs
+++ b/src/protocol/memcache/src/lib.rs
@@ -18,7 +18,7 @@ pub use storage::*;
 
 pub use protocol_common::*;
 
-use common::expiry::TimeType;
+pub use common::expiry::TimeType;
 use logger::Klog;
 use metriken::time::*;
 use metriken::*;

--- a/src/protocol/memcache/src/request/mod.rs
+++ b/src/protocol/memcache/src/request/mod.rs
@@ -3,7 +3,6 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::*;
-use common::expiry::TimeType;
 use core::fmt::{Display, Formatter};
 use core::num::NonZeroI32;
 use protocol_common::{BufMut, Parse, ParseOk};


### PR DESCRIPTION
Export the TimeTime in the memcache protocol crate so that clients can construct requests with TTLs.