### PR TITLE
feat: add iterator for resp array messages

### DIFF
--- a/src/protocol/resp/src/message/array.rs
+++ b/src/protocol/resp/src/message/array.rs
@@ -143,9 +143,11 @@ mod tests {
         assert_eq!(message.into_iter().next(), None);
 
         let message = Array {
-            inner: Some(vec![Message::bulk_string(b"HELLO")])
+            inner: Some(vec![Message::bulk_string(b"HELLO")]),
         };
-        assert_eq!(message.into_iter().next(), Some(&Message::bulk_string(b"HELLO")));
-
+        assert_eq!(
+            message.into_iter().next(),
+            Some(&Message::bulk_string(b"HELLO"))
+        );
     }
 }


### PR DESCRIPTION
Adds an iterator for resp array messages so that clients can iterate through all messages in an array message.