### PR TITLE
prepare pelikan-net for publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,8 +28,8 @@ dependencies = [
  "libc",
  "logger",
  "metriken",
- "net",
  "parking_lot",
+ "pelikan-net",
  "protocol-admin",
  "protocol-common",
  "session",
@@ -580,7 +580,7 @@ dependencies = [
  "boring",
  "clocksource",
  "metriken",
- "net",
+ "pelikan-net",
  "ringlog",
  "serde",
 ]
@@ -1540,7 +1540,7 @@ dependencies = [
  "logger",
  "metriken",
  "momento",
- "net",
+ "pelikan-net",
  "protocol-admin",
  "protocol-memcache",
  "protocol-resp",
@@ -1561,18 +1561,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "net"
-version = "0.3.1"
-dependencies = [
- "boring",
- "boring-sys",
- "foreign-types-shared",
- "libc",
- "metriken",
- "mio 0.8.8",
-]
 
 [[package]]
 name = "net2"
@@ -1705,6 +1693,18 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pelikan-net"
+version = "0.3.1"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "foreign-types-shared",
+ "libc",
+ "metriken",
+ "mio 0.8.8",
+]
 
 [[package]]
 name = "pelikan-segcache"
@@ -2079,7 +2079,7 @@ dependencies = [
  "entrystore",
  "logger",
  "metriken",
- "net",
+ "pelikan-net",
  "protocol-admin",
  "protocol-common",
  "session",
@@ -2452,7 +2452,7 @@ dependencies = [
  "libc",
  "logger",
  "metriken",
- "net",
+ "pelikan-net",
  "protocol-admin",
  "protocol-common",
  "session",
@@ -2469,7 +2469,7 @@ dependencies = [
  "common",
  "log",
  "metriken",
- "net",
+ "pelikan-net",
  "protocol-common",
 ]
 

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -13,6 +13,6 @@ license = { workspace = true }
 boring = { workspace = true }
 clocksource = { workspace = true }
 metriken = { workspace = true }
-net = { path = "../net" }
+pelikan-net = { path = "../net" }
 ringlog = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/src/common/src/ssl.rs
+++ b/src/common/src/ssl.rs
@@ -4,7 +4,7 @@
 
 pub use boring::ssl::*;
 
-use net::TlsTcpAcceptor;
+use pelikan_net::TlsTcpAcceptor;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
 pub trait TlsConfig {

--- a/src/core/admin/Cargo.toml
+++ b/src/core/admin/Cargo.toml
@@ -16,7 +16,7 @@ entrystore = { path = "../../entrystore" }
 libc = { workspace = true }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-net = { path = "../../net" }
+pelikan-net = { path = "../../net" }
 parking_lot = { workspace = true }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }

--- a/src/core/admin/src/lib.rs
+++ b/src/core/admin/src/lib.rs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use ::net::event::{Event, Source};
-use ::net::*;
 use common::signal::Signal;
 use common::ssl::tls_acceptor;
 use config::{AdminConfig, TlsConfig};
 use crossbeam_channel::Receiver;
 use logger::*;
 use metriken::*;
+use pelikan_net::event::{Event, Source};
+use pelikan_net::*;
 use protocol_admin::*;
 use session::{Buf, ServerSession, Session};
 use slab::Slab;
@@ -143,7 +143,7 @@ pub struct Admin {
     backlog: VecDeque<Token>,
     http_server: Option<tiny_http::Server>,
     /// The actual network listener for the ASCII Admin Endpoint
-    listener: ::net::Listener,
+    listener: pelikan_net::Listener,
     /// The drain handle for the logger
     log_drain: Box<dyn Drain>,
     /// The maximum number of events to process per call to poll
@@ -167,7 +167,7 @@ pub struct Admin {
 pub struct AdminBuilder {
     backlog: VecDeque<Token>,
     http_server: Option<tiny_http::Server>,
-    listener: ::net::Listener,
+    listener: pelikan_net::Listener,
     nevent: usize,
     poll: Poll,
     sessions: Slab<ServerSession<AdminRequestParser, AdminResponse, AdminRequest>>,
@@ -189,15 +189,15 @@ impl AdminBuilder {
         let tcp_listener = TcpListener::bind(addr)?;
 
         let mut listener = match (config.use_tls(), tls_acceptor(tls_config)?) {
-            (true, Some(tls_acceptor)) => ::net::Listener::from((tcp_listener, tls_acceptor)),
-            _ => ::net::Listener::from(tcp_listener),
+            (true, Some(tls_acceptor)) => pelikan_net::Listener::from((tcp_listener, tls_acceptor)),
+            _ => pelikan_net::Listener::from(tcp_listener),
         };
 
         let poll = Poll::new()?;
         listener.register(poll.registry(), LISTENER_TOKEN, Interest::READABLE)?;
 
         let waker = Arc::new(Waker::from(
-            ::net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
+            pelikan_net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
         ));
 
         let nevent = config.nevent();

--- a/src/core/proxy/Cargo.toml
+++ b/src/core/proxy/Cargo.toml
@@ -17,7 +17,7 @@ crossbeam-channel = { workspace = true }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-net = { path = "../../net" }
+pelikan-net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 session = { path = "../../session" }

--- a/src/core/proxy/src/backend.rs
+++ b/src/core/proxy/src/backend.rs
@@ -71,7 +71,7 @@ where
         let poll = Poll::new()?;
 
         let waker = Arc::new(Waker::from(
-            ::net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
+            pelikan_net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
         ));
 
         let nevent = config.nevent();

--- a/src/core/proxy/src/frontend.rs
+++ b/src/core/proxy/src/frontend.rs
@@ -79,7 +79,7 @@ impl<FrontendParser, FrontendRequest, FrontendResponse, BackendRequest, BackendR
         let poll = Poll::new()?;
 
         let waker = Arc::new(Waker::from(
-            ::net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
+            pelikan_net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
         ));
 
         let nevent = config.nevent();

--- a/src/core/proxy/src/lib.rs
+++ b/src/core/proxy/src/lib.rs
@@ -11,8 +11,6 @@ extern crate logger;
 #[macro_use]
 extern crate metriken;
 
-use ::net::event::{Event, Source};
-use ::net::*;
 use admin::AdminBuilder;
 use common::signal::Signal;
 use common::ssl::tls_acceptor;
@@ -24,6 +22,8 @@ use crossbeam_channel::{bounded, Receiver, Sender};
 use entrystore::EntryStore;
 use logger::Drain;
 use metriken::*;
+use pelikan_net::event::{Event, Source};
+use pelikan_net::*;
 use protocol_common::{Compose, Execute, Parse};
 use session::{Buf, ServerSession, Session};
 use slab::Slab;

--- a/src/core/proxy/src/listener.rs
+++ b/src/core/proxy/src/listener.rs
@@ -49,7 +49,7 @@ pub static LISTENER_EVENT_WRITE: Counter = Counter::new();
 pub static LISTENER_SESSION_DISCARD: Counter = Counter::new();
 
 pub struct ListenerBuilder {
-    listener: ::net::Listener,
+    listener: pelikan_net::Listener,
     nevent: usize,
     poll: Poll,
     sessions: Slab<Session>,
@@ -70,16 +70,16 @@ impl ListenerBuilder {
         let tcp_listener = TcpListener::bind(addr)?;
 
         let mut listener = if let Some(tls_acceptor) = tls_acceptor(tls_config)? {
-            ::net::Listener::from((tcp_listener, tls_acceptor))
+            pelikan_net::Listener::from((tcp_listener, tls_acceptor))
         } else {
-            ::net::Listener::from(tcp_listener)
+            pelikan_net::Listener::from(tcp_listener)
         };
 
         let poll = Poll::new()?;
         listener.register(poll.registry(), LISTENER_TOKEN, Interest::READABLE)?;
 
         let waker = Arc::new(Waker::from(
-            ::net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
+            pelikan_net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
         ));
 
         let nevent = config.nevent();
@@ -121,7 +121,7 @@ impl ListenerBuilder {
 
 pub struct Listener {
     /// The actual network listener server
-    listener: ::net::Listener,
+    listener: pelikan_net::Listener,
     /// The maximum number of events to process per call to poll
     nevent: usize,
     /// The actual poll instantance

--- a/src/core/server/Cargo.toml
+++ b/src/core/server/Cargo.toml
@@ -18,7 +18,7 @@ entrystore = { path = "../../entrystore" }
 libc = {workspace = true}
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-net = { path = "../../net" }
+pelikan-net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 session = { path = "../../session" }

--- a/src/core/server/src/lib.rs
+++ b/src/core/server/src/lib.rs
@@ -91,8 +91,6 @@
 #[macro_use]
 extern crate logger;
 
-use ::net::event::{Event, Source};
-use ::net::*;
 use admin::AdminBuilder;
 use common::signal::Signal;
 use common::ssl::tls_acceptor;
@@ -103,6 +101,8 @@ use crossbeam_channel::{bounded, Sender};
 use entrystore::EntryStore;
 use logger::{Drain, Klog};
 use metriken::*;
+use pelikan_net::event::{Event, Source};
+use pelikan_net::*;
 use protocol_common::{Compose, Execute, Parse};
 use session::{Buf, ServerSession, Session};
 use slab::Slab;

--- a/src/core/server/src/listener.rs
+++ b/src/core/server/src/listener.rs
@@ -49,7 +49,7 @@ pub static LISTENER_SESSION_DISCARD: Counter = Counter::new();
 
 pub struct Listener {
     /// The actual network listener server
-    listener: ::net::Listener,
+    listener: pelikan_net::Listener,
     /// The maximum number of events to process per call to poll
     nevent: usize,
     /// The actual poll instantance
@@ -68,7 +68,7 @@ pub struct Listener {
 }
 
 pub struct ListenerBuilder {
-    listener: ::net::Listener,
+    listener: pelikan_net::Listener,
     nevent: usize,
     poll: Poll,
     sessions: Slab<Session>,
@@ -89,16 +89,16 @@ impl ListenerBuilder {
         let tcp_listener = TcpListener::bind(addr)?;
 
         let mut listener = if let Some(tls_acceptor) = tls_acceptor(tls_config)? {
-            ::net::Listener::from((tcp_listener, tls_acceptor))
+            pelikan_net::Listener::from((tcp_listener, tls_acceptor))
         } else {
-            ::net::Listener::from(tcp_listener)
+            pelikan_net::Listener::from(tcp_listener)
         };
 
         let poll = Poll::new()?;
         listener.register(poll.registry(), LISTENER_TOKEN, Interest::READABLE)?;
 
         let waker = Arc::new(Waker::from(
-            ::net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
+            pelikan_net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
         ));
 
         let nevent = config.nevent();

--- a/src/core/server/src/workers/multi.rs
+++ b/src/core/server/src/workers/multi.rs
@@ -20,7 +20,7 @@ impl<Parser, Request, Response> MultiWorkerBuilder<Parser, Request, Response> {
         let poll = Poll::new()?;
 
         let waker = Arc::new(Waker::from(
-            ::net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
+            pelikan_net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
         ));
 
         let nevent = config.nevent();

--- a/src/core/server/src/workers/single.rs
+++ b/src/core/server/src/workers/single.rs
@@ -23,7 +23,7 @@ impl<Parser, Request, Response, Storage> SingleWorkerBuilder<Parser, Request, Re
         let poll = Poll::new()?;
 
         let waker = Arc::new(Waker::from(
-            ::net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
+            pelikan_net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
         ));
 
         let nevent = config.nevent();

--- a/src/core/server/src/workers/storage.rs
+++ b/src/core/server/src/workers/storage.rs
@@ -33,7 +33,7 @@ impl<Request, Response, Storage> StorageWorkerBuilder<Request, Response, Storage
         let poll = Poll::new()?;
 
         let waker = Arc::new(Waker::from(
-            ::net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
+            pelikan_net::Waker::new(poll.registry(), WAKER_TOKEN).unwrap(),
         ));
 
         let nevent = config.nevent();

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "net"
-description = "Networking abstractions for non-blocking event loops"
+name = "pelikan-net"
+description = "Pelikan project's networking abstractions for non-blocking event loops"
 authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }

--- a/src/proxy/momento/Cargo.toml
+++ b/src/proxy/momento/Cargo.toml
@@ -19,7 +19,7 @@ libc = { workspace = true }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
 momento = "0.32.0"
-net = { path = "../../net" }
+pelikan-net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-memcache = { path = "../../protocol/memcache" }
 protocol-resp = { path = "../../protocol/resp" }

--- a/src/proxy/momento/src/frontend.rs
+++ b/src/proxy/momento/src/frontend.rs
@@ -4,7 +4,7 @@
 
 use crate::protocol::*;
 use crate::*;
-use net::TCP_SEND_BYTE;
+use pelikan_net::TCP_SEND_BYTE;
 use session::Buf;
 
 pub(crate) async fn handle_memcache_client(

--- a/src/proxy/momento/src/listener.rs
+++ b/src/proxy/momento/src/listener.rs
@@ -3,7 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::*;
-use ::net::{TCP_ACCEPT, TCP_CLOSE, TCP_CONN_CURR};
+use pelikan_net::{TCP_ACCEPT, TCP_CLOSE, TCP_CONN_CURR};
 
 pub(crate) async fn listener(
     listener: TcpListener,

--- a/src/proxy/momento/src/main.rs
+++ b/src/proxy/momento/src/main.rs
@@ -16,7 +16,7 @@ use logger::configure_logging;
 use logger::Drain;
 use metriken::*;
 use momento::*;
-use net::TCP_RECV_BYTE;
+use pelikan_net::TCP_RECV_BYTE;
 use protocol_admin::*;
 use session::*;
 use std::borrow::{Borrow, BorrowMut};

--- a/src/proxy/momento/src/protocol/memcache/delete.rs
+++ b/src/proxy/momento/src/protocol/memcache/delete.rs
@@ -1,6 +1,6 @@
 use crate::klog::{klog_1, Status};
 use crate::{Error, *};
-use ::net::*;
+use pelikan_net::*;
 use protocol_memcache::*;
 
 pub async fn delete(

--- a/src/proxy/momento/src/protocol/memcache/get.rs
+++ b/src/proxy/momento/src/protocol/memcache/get.rs
@@ -4,7 +4,7 @@
 
 use crate::klog::{klog_1, Status};
 use crate::{Error, *};
-use ::net::*;
+use pelikan_net::*;
 use momento::response::Get as GetResponse;
 use protocol_memcache::*;
 

--- a/src/proxy/momento/src/protocol/memcache/get.rs
+++ b/src/proxy/momento/src/protocol/memcache/get.rs
@@ -4,8 +4,8 @@
 
 use crate::klog::{klog_1, Status};
 use crate::{Error, *};
-use pelikan_net::*;
 use momento::response::Get as GetResponse;
+use pelikan_net::*;
 use protocol_memcache::*;
 
 pub async fn get(

--- a/src/proxy/momento/src/protocol/memcache/set.rs
+++ b/src/proxy/momento/src/protocol/memcache/set.rs
@@ -4,7 +4,7 @@
 
 use crate::klog::{klog_set, Status};
 use crate::{Error, *};
-use ::net::*;
+use pelikan_net::*;
 use protocol_memcache::*;
 
 pub async fn set(

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -13,5 +13,5 @@ bytes = { workspace = true }
 common = { path = "../common" }
 log = { workspace = true }
 metriken = { workspace = true }
-net = { path = "../net" }
+pelikan-net = { path = "../net" }
 protocol-common = { path = "../protocol/common" }

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -22,7 +22,7 @@ pub use server::ServerSession;
 
 use std::os::unix::prelude::AsRawFd;
 
-use ::net::*;
+use pelikan_net::*;
 use common::time::Nanoseconds;
 use core::borrow::{Borrow, BorrowMut};
 use core::fmt::Debug;

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -22,12 +22,12 @@ pub use server::ServerSession;
 
 use std::os::unix::prelude::AsRawFd;
 
-use pelikan_net::*;
 use common::time::Nanoseconds;
 use core::borrow::{Borrow, BorrowMut};
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use metriken::*;
+use pelikan_net::*;
 use protocol_common::Compose;
 use protocol_common::Parse;
 use std::collections::VecDeque;


### PR DESCRIPTION
Renames the `net` crate to `pelikan-net` to prepare to publish it.