### PR TITLE
use versioned pelikan-net crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ metrohash = "1.0.6"
 mio = "0.8.8"
 nom = "7.1.3"
 parking_lot = "0.12.1"
+pelikan-net = { path = "./src/net", version = "0.1.0" }
 phf = "0.11.2"
 proc-macro2 = "1.0.69"
 quote = "1.0.33"

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -13,6 +13,6 @@ license = { workspace = true }
 boring = { workspace = true }
 clocksource = { workspace = true }
 metriken = { workspace = true }
-pelikan-net = { path = "../net" }
+pelikan-net = { workspace = true }
 ringlog = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/src/core/admin/Cargo.toml
+++ b/src/core/admin/Cargo.toml
@@ -16,7 +16,7 @@ entrystore = { path = "../../entrystore" }
 libc = { workspace = true }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-pelikan-net = { path = "../../net" }
+pelikan-net = { workspace = true }
 parking_lot = { workspace = true }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }

--- a/src/core/proxy/Cargo.toml
+++ b/src/core/proxy/Cargo.toml
@@ -17,7 +17,7 @@ crossbeam-channel = { workspace = true }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-pelikan-net = { path = "../../net" }
+pelikan-net = { workspace = true }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 session = { path = "../../session" }

--- a/src/core/server/Cargo.toml
+++ b/src/core/server/Cargo.toml
@@ -18,7 +18,7 @@ entrystore = { path = "../../entrystore" }
 libc = {workspace = true}
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-pelikan-net = { path = "../../net" }
+pelikan-net = { workspace = true }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 session = { path = "../../session" }

--- a/src/proxy/momento/Cargo.toml
+++ b/src/proxy/momento/Cargo.toml
@@ -19,7 +19,7 @@ libc = { workspace = true }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
 momento = "0.32.0"
-pelikan-net = { path = "../../net" }
+pelikan-net = { workspace = true }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-memcache = { path = "../../protocol/memcache" }
 protocol-resp = { path = "../../protocol/resp" }

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -13,5 +13,5 @@ bytes = { workspace = true }
 common = { path = "../common" }
 log = { workspace = true }
 metriken = { workspace = true }
-pelikan-net = { path = "../net" }
+pelikan-net = { workspace = true }
 protocol-common = { path = "../protocol/common" }


### PR DESCRIPTION
Sets the pelikan-net dependency version at the workspace level and moves all dependencies to use the workspace dependency.