### PR TITLE
session: remove transisitive dependency on boringssl

### DIFF
--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -11,8 +11,8 @@ license = { workspace = true }
 [dependencies]
 bytes = { workspace = true }
 clocksource = { workspace = true }
-common = { path = "../common" }
+common = { path = "../common", default-features = false }
 log = { workspace = true }
 metriken = { workspace = true }
-pelikan-net = { workspace = true }
-protocol-common = { path = "../protocol/common" }
+pelikan-net = { workspace = true, default-features = false }
+protocol-common = { path = "../protocol/common", default-features = false }


### PR DESCRIPTION
Removes the transitive dependency on boringssl by restricting the set of features enabled on direct dependencies for session crate.