### PR TITLE
pelikan-net: make metrics opt-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "admin"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "common",
  "config",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "bloom"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bitvec",
  "criterion",
@@ -511,7 +511,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "common"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "boring",
  "clocksource",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "common",
  "log",
@@ -667,7 +667,7 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "entrystore"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "common",
  "config",
@@ -1167,7 +1167,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "logger"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "common",
  "config",
@@ -1491,7 +1491,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pelikan-net"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "boring",
  "boring-sys",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "pelikan-segcache"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "backtrace",
  "clap",
@@ -1611,7 +1611,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pingproxy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "backtrace",
  "clap",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "pingserver"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "backtrace",
  "clap",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-admin"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "common",
  "config",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-common"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes",
  "common",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-http"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arrayvec",
  "assert_matches",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-memcache"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clocksource",
  "common",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-ping"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "common",
  "config",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-resp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bstr",
  "common",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-thrift"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "common",
  "logger",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "proxy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "admin",
  "clocksource",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "rds"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "backtrace",
  "clap",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "admin",
  "common",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes",
  "clocksource",
@@ -2324,7 +2324,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-types"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "strsim"
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "thriftproxy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "backtrace",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 homepage = "https://pelikan.io"
 repository = "https://github.com/pelikan-io/pelikan"
@@ -62,7 +62,7 @@ nom = "7.1.3"
 openssl = "0.10.64"
 openssl-sys = "0.9.102"
 parking_lot = "0.12.1"
-pelikan-net = { path = "./src/net", version = "0.3.0", default-features = false }
+pelikan-net = { path = "./src/net", version = "0.4.0", default-features = false, features = ["boringssl", "metrics"] }
 phf = "0.11.2"
 proc-macro2 = "1.0.69"
 quote = "1.0.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ bytes = "1.5.0"
 clap = "4.4.6"
 clocksource = "0.8.1"
 crossbeam-channel = "0.5.8"
-datatier = { path = "./src/storage/datatier", version = "0.1.0"}
+datatier = { path = "./src/storage/datatier", version = "0.1.0" }
 httparse = "1.8.0"
 libc = "0.2.149"
 log = "0.4.20"
@@ -62,7 +62,7 @@ nom = "7.1.3"
 openssl = "0.10.64"
 openssl-sys = "0.9.102"
 parking_lot = "0.12.1"
-pelikan-net = { path = "./src/net", version = "0.4.0", default-features = false, features = ["boringssl", "metrics"] }
+pelikan-net = { path = "./src/net", version = "0.4.0" }
 phf = "0.11.2"
 proc-macro2 = "1.0.69"
 quote = "1.0.33"

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -13,10 +13,9 @@ license = { workspace = true }
 boring = { workspace = true, optional = true }
 clocksource = { workspace = true }
 metriken = { workspace = true }
-pelikan-net = { workspace = true, default-features = false }
+pelikan-net = { workspace = true }
 ringlog = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
 [features]
-default = ["boringssl"]
 boringssl = ["dep:boring", "pelikan-net/boringssl"]

--- a/src/core/proxy/Cargo.toml
+++ b/src/core/proxy/Cargo.toml
@@ -17,9 +17,13 @@ crossbeam-channel = { workspace = true }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-pelikan-net = { workspace = true }
+pelikan-net = { workspace = true, features = ["metrics"] }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 session = { path = "../../session" }
 slab = { workspace = true }
 switchboard = { workspace = true }
+
+[features]
+boringssl = ["pelikan-net/boringssl"]
+openssl = ["pelikan-net/openssl"]

--- a/src/core/server/Cargo.toml
+++ b/src/core/server/Cargo.toml
@@ -18,10 +18,14 @@ entrystore = { path = "../../entrystore" }
 libc = {workspace = true}
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-pelikan-net = { workspace = true }
+pelikan-net = { workspace = true, features = ["metrics"] }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 session = { path = "../../session" }
 signal-hook = {workspace = true}
 slab = { workspace = true }
 switchboard = { workspace = true }
+
+[features]
+boringssl = ["pelikan-net/boringssl"]
+openssl = ["pelikan-net/openssl"]

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -21,7 +21,6 @@ openssl = { workspace = true, optional = true }
 openssl-sys = { workspace = true, optional = true }
 
 [features]
-default = ["boringssl"]
 boringssl = ["boring", "boring-sys"]
 metrics = ["metriken"]
 openssl = ["dep:openssl", "openssl-sys", "openssl/vendored"]

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pelikan-net"
 description = "Pelikan project's networking abstractions for non-blocking event loops"
 authors = ["Brian Martin <brian@pelikan.io>"]
-version = "0.3.0"
+version = "0.4.0"
 
 edition = { workspace = true }
 homepage = { workspace = true }
@@ -15,7 +15,7 @@ boring-sys = { workspace = true, optional = true }
 foreign-types-shared_03 = { package = "foreign-types-shared", version = "0.3.1" }
 foreign-types-shared_01 = { package = "foreign-types-shared", version = "0.1.1" }
 libc = { workspace = true }
-metriken = { workspace = true }
+metriken = { workspace = true, optional = true }
 mio = { workspace = true, features = ["os-poll", "net"] }
 openssl = { workspace = true, optional = true }
 openssl-sys = { workspace = true, optional = true }
@@ -23,4 +23,5 @@ openssl-sys = { workspace = true, optional = true }
 [features]
 default = ["boringssl"]
 boringssl = ["boring", "boring-sys"]
+metrics = ["metriken"]
 openssl = ["dep:openssl", "openssl-sys", "openssl/vendored"]

--- a/src/net/src/lib.rs
+++ b/src/net/src/lib.rs
@@ -31,16 +31,16 @@ mod metrics;
 pub use metrics::*;
 
 #[cfg(feature = "metrics")]
-macro_rules! metrics {
+macro_rules! metric {
     { $( $tt:tt )* } => { $( $tt )* }
 }
 
 #[cfg(not(feature = "metrics"))]
-macro_rules! metrics {
+macro_rules! metric {
     { $( $tt:tt)* } => {}
 }
 
-pub(crate) use metrics;
+pub(crate) use metric;
 
 use core::fmt::Debug;
 use core::ops::Deref;

--- a/src/net/src/lib.rs
+++ b/src/net/src/lib.rs
@@ -30,6 +30,18 @@ mod metrics;
 #[cfg(feature = "metrics")]
 pub use metrics::*;
 
+#[cfg(feature = "metrics")]
+macro_rules! metrics {
+    { $( $tt:tt )* } => { $( $tt )* }
+}
+
+#[cfg(not(feature = "metrics"))]
+macro_rules! metrics {
+    { $( $tt:tt)* } => {}
+}
+
+pub(crate) use metrics;
+
 use core::fmt::Debug;
 use core::ops::Deref;
 use std::io::{Error, ErrorKind, Read, Write};

--- a/src/net/src/lib.rs
+++ b/src/net/src/lib.rs
@@ -24,82 +24,15 @@ pub mod event {
 
 pub use mio::*;
 
+#[cfg(feature = "metrics")]
+mod metrics;
+
+#[cfg(feature = "metrics")]
+pub use metrics::*;
+
 use core::fmt::Debug;
 use core::ops::Deref;
 use std::io::{Error, ErrorKind, Read, Write};
 use std::net::{SocketAddr, ToSocketAddrs};
 
-use metriken::*;
-
 type Result<T> = std::io::Result<T>;
-
-// stats
-
-#[metric(
-    name = "tcp_accept",
-    description = "number of TCP streams passively opened with accept"
-)]
-pub static TCP_ACCEPT: Counter = Counter::new();
-
-#[metric(
-    name = "tcp_connect",
-    description = "number of TCP streams actively opened with connect"
-)]
-pub static TCP_CONNECT: Counter = Counter::new();
-
-#[metric(name = "tcp_close", description = "number of TCP streams closed")]
-pub static TCP_CLOSE: Counter = Counter::new();
-
-#[metric(
-    name = "tcp_conn_curr",
-    description = "current number of open TCP streams"
-)]
-pub static TCP_CONN_CURR: Gauge = Gauge::new();
-
-#[metric(
-    name = "tcp_recv_byte",
-    description = "number of bytes received on TCP streams"
-)]
-pub static TCP_RECV_BYTE: Counter = Counter::new();
-
-#[metric(
-    name = "tcp_send_byte",
-    description = "number of bytes sent on TCP streams"
-)]
-pub static TCP_SEND_BYTE: Counter = Counter::new();
-
-#[metric(name = "stream_accept", description = "number of calls to accept")]
-pub static STREAM_ACCEPT: Counter = Counter::new();
-
-#[metric(
-    name = "stream_accept_ex",
-    description = "number of times calling accept resulted in an exception"
-)]
-pub static STREAM_ACCEPT_EX: Counter = Counter::new();
-
-#[metric(name = "stream_close", description = "number of streams closed")]
-pub static STREAM_CLOSE: Counter = Counter::new();
-
-#[metric(
-    name = "stream_handshake",
-    description = "number of times stream handshaking was attempted"
-)]
-pub static STREAM_HANDSHAKE: Counter = Counter::new();
-
-#[metric(
-    name = "stream_handshake_ex",
-    description = "number of exceptions while handshaking"
-)]
-pub static STREAM_HANDSHAKE_EX: Counter = Counter::new();
-
-#[metric(
-    name = "stream_shutdown",
-    description = "number of streams gracefully shutdown"
-)]
-pub static STREAM_SHUTDOWN: Counter = Counter::new();
-
-#[metric(
-    name = "stream_shutdown_ex",
-    description = "number of exceptions while attempting to gracefully shutdown a stream"
-)]
-pub static STREAM_SHUTDOWN_EX: Counter = Counter::new();

--- a/src/net/src/listener.rs
+++ b/src/net/src/listener.rs
@@ -38,15 +38,16 @@ impl Listener {
     /// the operation should be retried again in the future.
     ///
     /// All other errors should be treated as failures.
+    #[allow(clippy::let_and_return)]
     pub fn accept(&self) -> Result<Stream> {
-        #[cfg(feature = "metrics")]
-        STREAM_ACCEPT.increment();
-
         let result = self._accept();
 
-        #[cfg(feature = "metrics")]
-        if result.is_err() {
-            STREAM_ACCEPT_EX.increment();
+        metrics! {
+            STREAM_ACCEPT.increment();
+
+            if result.is_err() {
+                STREAM_ACCEPT_EX.increment();
+            }
         }
 
         result

--- a/src/net/src/listener.rs
+++ b/src/net/src/listener.rs
@@ -39,11 +39,16 @@ impl Listener {
     ///
     /// All other errors should be treated as failures.
     pub fn accept(&self) -> Result<Stream> {
+        #[cfg(feature = "metrics")]
         STREAM_ACCEPT.increment();
+
         let result = self._accept();
+
+        #[cfg(feature = "metrics")]
         if result.is_err() {
             STREAM_ACCEPT_EX.increment();
         }
+
         result
     }
 

--- a/src/net/src/listener.rs
+++ b/src/net/src/listener.rs
@@ -42,7 +42,7 @@ impl Listener {
     pub fn accept(&self) -> Result<Stream> {
         let result = self._accept();
 
-        metrics! {
+        metric! {
             STREAM_ACCEPT.increment();
 
             if result.is_err() {

--- a/src/net/src/metrics.rs
+++ b/src/net/src/metrics.rs
@@ -1,0 +1,70 @@
+use metriken::*;
+
+#[metric(
+    name = "tcp_accept",
+    description = "number of TCP streams passively opened with accept"
+)]
+pub static TCP_ACCEPT: Counter = Counter::new();
+
+#[metric(
+    name = "tcp_connect",
+    description = "number of TCP streams actively opened with connect"
+)]
+pub static TCP_CONNECT: Counter = Counter::new();
+
+#[metric(name = "tcp_close", description = "number of TCP streams closed")]
+pub static TCP_CLOSE: Counter = Counter::new();
+
+#[metric(
+    name = "tcp_conn_curr",
+    description = "current number of open TCP streams"
+)]
+pub static TCP_CONN_CURR: Gauge = Gauge::new();
+
+#[metric(
+    name = "tcp_recv_byte",
+    description = "number of bytes received on TCP streams"
+)]
+pub static TCP_RECV_BYTE: Counter = Counter::new();
+
+#[metric(
+    name = "tcp_send_byte",
+    description = "number of bytes sent on TCP streams"
+)]
+pub static TCP_SEND_BYTE: Counter = Counter::new();
+
+#[metric(name = "stream_accept", description = "number of calls to accept")]
+pub static STREAM_ACCEPT: Counter = Counter::new();
+
+#[metric(
+    name = "stream_accept_ex",
+    description = "number of times calling accept resulted in an exception"
+)]
+pub static STREAM_ACCEPT_EX: Counter = Counter::new();
+
+#[metric(name = "stream_close", description = "number of streams closed")]
+pub static STREAM_CLOSE: Counter = Counter::new();
+
+#[metric(
+    name = "stream_handshake",
+    description = "number of times stream handshaking was attempted"
+)]
+pub static STREAM_HANDSHAKE: Counter = Counter::new();
+
+#[metric(
+    name = "stream_handshake_ex",
+    description = "number of exceptions while handshaking"
+)]
+pub static STREAM_HANDSHAKE_EX: Counter = Counter::new();
+
+#[metric(
+    name = "stream_shutdown",
+    description = "number of streams gracefully shutdown"
+)]
+pub static STREAM_SHUTDOWN: Counter = Counter::new();
+
+#[metric(
+    name = "stream_shutdown_ex",
+    description = "number of exceptions while attempting to gracefully shutdown a stream"
+)]
+pub static STREAM_SHUTDOWN_EX: Counter = Counter::new();

--- a/src/net/src/stream.rs
+++ b/src/net/src/stream.rs
@@ -81,7 +81,10 @@ impl Stream {
             StreamType::TlsTcp(s) => s.shutdown().map(|v| v == ShutdownResult::Received),
         };
 
+        #[cfg(feature = "metrics")]
         STREAM_SHUTDOWN.increment();
+
+        #[cfg(feature = "metrics")]
         if result.is_err() {
             STREAM_SHUTDOWN_EX.increment();
         }
@@ -92,6 +95,7 @@ impl Stream {
 
 impl Drop for Stream {
     fn drop(&mut self) {
+        #[cfg(feature = "metrics")]
         STREAM_CLOSE.increment();
     }
 }

--- a/src/net/src/stream.rs
+++ b/src/net/src/stream.rs
@@ -74,6 +74,7 @@ impl Stream {
         }
     }
 
+    #[allow(clippy::let_and_return)]
     pub fn shutdown(&mut self) -> Result<bool> {
         let result = match &mut self.inner {
             StreamType::Tcp(s) => s.shutdown(Shutdown::Both).map(|_| true),
@@ -81,12 +82,12 @@ impl Stream {
             StreamType::TlsTcp(s) => s.shutdown().map(|v| v == ShutdownResult::Received),
         };
 
-        #[cfg(feature = "metrics")]
-        STREAM_SHUTDOWN.increment();
+        metrics! {
+            STREAM_SHUTDOWN.increment();
 
-        #[cfg(feature = "metrics")]
-        if result.is_err() {
-            STREAM_SHUTDOWN_EX.increment();
+            if result.is_err() {
+                STREAM_SHUTDOWN_EX.increment();
+            }
         }
 
         result
@@ -95,8 +96,9 @@ impl Stream {
 
 impl Drop for Stream {
     fn drop(&mut self) {
-        #[cfg(feature = "metrics")]
-        STREAM_CLOSE.increment();
+        metrics! {
+            STREAM_CLOSE.increment();
+        }
     }
 }
 

--- a/src/net/src/stream.rs
+++ b/src/net/src/stream.rs
@@ -82,7 +82,7 @@ impl Stream {
             StreamType::TlsTcp(s) => s.shutdown().map(|v| v == ShutdownResult::Received),
         };
 
-        metrics! {
+        metric! {
             STREAM_SHUTDOWN.increment();
 
             if result.is_err() {
@@ -96,7 +96,7 @@ impl Stream {
 
 impl Drop for Stream {
     fn drop(&mut self) {
-        metrics! {
+        metric! {
             STREAM_CLOSE.increment();
         }
     }

--- a/src/net/src/tcp.rs
+++ b/src/net/src/tcp.rs
@@ -20,8 +20,11 @@ impl TcpStream {
     pub fn connect(addr: SocketAddr) -> Result<Self> {
         let inner = mio::net::TcpStream::connect(addr)?;
 
-        TCP_CONN_CURR.increment();
-        TCP_CONNECT.increment();
+        #[cfg(feature = "metrics")]
+        {
+            TCP_CONN_CURR.increment();
+            TCP_CONNECT.increment();
+        }
 
         Ok(Self {
             inner,
@@ -58,8 +61,11 @@ impl TcpStream {
 
 impl Drop for TcpStream {
     fn drop(&mut self) {
-        TCP_CONN_CURR.decrement();
-        TCP_CLOSE.increment();
+        #[cfg(feature = "metrics")]
+        {
+            TCP_CONN_CURR.decrement();
+            TCP_CLOSE.increment();
+        }
     }
 }
 
@@ -81,7 +87,9 @@ impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self.inner.read(buf) {
             Ok(amt) => {
+                #[cfg(feature = "metrics")]
                 TCP_RECV_BYTE.add(amt as _);
+
                 Ok(amt)
             }
             Err(e) => Err(e),
@@ -93,7 +101,9 @@ impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         match self.inner.write(buf) {
             Ok(amt) => {
+                #[cfg(feature = "metrics")]
                 TCP_SEND_BYTE.add(amt as _);
+
                 Ok(amt)
             }
             Err(e) => Err(e),
@@ -177,6 +187,7 @@ impl TcpListener {
             )
         });
 
+        #[cfg(feature = "metrics")]
         if result.is_ok() {
             TCP_ACCEPT.increment();
             TCP_CONN_CURR.increment();

--- a/src/net/src/tcp.rs
+++ b/src/net/src/tcp.rs
@@ -20,7 +20,7 @@ impl TcpStream {
     pub fn connect(addr: SocketAddr) -> Result<Self> {
         let inner = mio::net::TcpStream::connect(addr)?;
 
-        metrics! {
+        metric! {
             TCP_CONN_CURR.increment();
             TCP_CONNECT.increment();
         }
@@ -60,7 +60,7 @@ impl TcpStream {
 
 impl Drop for TcpStream {
     fn drop(&mut self) {
-        metrics! {
+        metric! {
             TCP_CONN_CURR.decrement();
             TCP_CLOSE.increment();
         }
@@ -85,7 +85,7 @@ impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self.inner.read(buf) {
             Ok(amt) => {
-                metrics! {
+                metric! {
                     TCP_RECV_BYTE.add(amt as _);
                 }
 
@@ -100,7 +100,7 @@ impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         match self.inner.write(buf) {
             Ok(amt) => {
-                metrics! {
+                metric! {
                     TCP_SEND_BYTE.add(amt as _);
                 }
 
@@ -188,7 +188,7 @@ impl TcpListener {
             )
         });
 
-        metrics! {
+        metric! {
             if result.is_ok() {
                 TCP_ACCEPT.increment();
                 TCP_CONN_CURR.increment();

--- a/src/net/src/tcp.rs
+++ b/src/net/src/tcp.rs
@@ -20,8 +20,7 @@ impl TcpStream {
     pub fn connect(addr: SocketAddr) -> Result<Self> {
         let inner = mio::net::TcpStream::connect(addr)?;
 
-        #[cfg(feature = "metrics")]
-        {
+        metrics! {
             TCP_CONN_CURR.increment();
             TCP_CONNECT.increment();
         }
@@ -61,8 +60,7 @@ impl TcpStream {
 
 impl Drop for TcpStream {
     fn drop(&mut self) {
-        #[cfg(feature = "metrics")]
-        {
+        metrics! {
             TCP_CONN_CURR.decrement();
             TCP_CLOSE.increment();
         }
@@ -87,8 +85,9 @@ impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self.inner.read(buf) {
             Ok(amt) => {
-                #[cfg(feature = "metrics")]
-                TCP_RECV_BYTE.add(amt as _);
+                metrics! {
+                    TCP_RECV_BYTE.add(amt as _);
+                }
 
                 Ok(amt)
             }
@@ -101,8 +100,9 @@ impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         match self.inner.write(buf) {
             Ok(amt) => {
-                #[cfg(feature = "metrics")]
-                TCP_SEND_BYTE.add(amt as _);
+                metrics! {
+                    TCP_SEND_BYTE.add(amt as _);
+                }
 
                 Ok(amt)
             }
@@ -176,6 +176,7 @@ impl TcpListener {
         Ok(Self { inner })
     }
 
+    #[allow(clippy::let_and_return)]
     pub fn accept(&self) -> Result<(TcpStream, SocketAddr)> {
         let result = self.inner.accept().map(|(stream, addr)| {
             (
@@ -187,10 +188,11 @@ impl TcpListener {
             )
         });
 
-        #[cfg(feature = "metrics")]
-        if result.is_ok() {
-            TCP_ACCEPT.increment();
-            TCP_CONN_CURR.increment();
+        metrics! {
+            if result.is_ok() {
+                TCP_ACCEPT.increment();
+                TCP_CONN_CURR.increment();
+            }
         }
 
         result

--- a/src/net/src/tls_tcp/boringssl.rs
+++ b/src/net/src/tls_tcp/boringssl.rs
@@ -50,8 +50,11 @@ impl TlsTcpStream {
             let ptr = self.inner.ssl().as_ptr();
             let ret = unsafe { boring_sys::SSL_do_handshake(ptr) };
             if ret > 0 {
+                #[cfg(feature = "metrics")]
                 STREAM_HANDSHAKE.increment();
+
                 self.state = TlsState::Negotiated;
+
                 Ok(())
             } else {
                 let code = unsafe { ErrorCode::from_raw(boring_sys::SSL_get_error(ptr, ret)) };
@@ -60,8 +63,12 @@ impl TlsTcpStream {
                         Err(Error::from(ErrorKind::WouldBlock))
                     }
                     _ => {
-                        STREAM_HANDSHAKE.increment();
-                        STREAM_HANDSHAKE_EX.increment();
+                        #[cfg(feature = "metrics")]
+                        {
+                            STREAM_HANDSHAKE.increment();
+                            STREAM_HANDSHAKE_EX.increment();
+                        }
+
                         Err(Error::new(ErrorKind::Other, "handshake failed"))
                     }
                 }

--- a/src/net/src/tls_tcp/boringssl.rs
+++ b/src/net/src/tls_tcp/boringssl.rs
@@ -50,8 +50,9 @@ impl TlsTcpStream {
             let ptr = self.inner.ssl().as_ptr();
             let ret = unsafe { boring_sys::SSL_do_handshake(ptr) };
             if ret > 0 {
-                #[cfg(feature = "metrics")]
-                STREAM_HANDSHAKE.increment();
+                metrics! {
+                    STREAM_HANDSHAKE.increment();
+                }
 
                 self.state = TlsState::Negotiated;
 
@@ -63,8 +64,7 @@ impl TlsTcpStream {
                         Err(Error::from(ErrorKind::WouldBlock))
                     }
                     _ => {
-                        #[cfg(feature = "metrics")]
-                        {
+                        metrics! {
                             STREAM_HANDSHAKE.increment();
                             STREAM_HANDSHAKE_EX.increment();
                         }

--- a/src/net/src/tls_tcp/boringssl.rs
+++ b/src/net/src/tls_tcp/boringssl.rs
@@ -50,7 +50,7 @@ impl TlsTcpStream {
             let ptr = self.inner.ssl().as_ptr();
             let ret = unsafe { boring_sys::SSL_do_handshake(ptr) };
             if ret > 0 {
-                metrics! {
+                metric! {
                     STREAM_HANDSHAKE.increment();
                 }
 
@@ -64,7 +64,7 @@ impl TlsTcpStream {
                         Err(Error::from(ErrorKind::WouldBlock))
                     }
                     _ => {
-                        metrics! {
+                        metric! {
                             STREAM_HANDSHAKE.increment();
                             STREAM_HANDSHAKE_EX.increment();
                         }

--- a/src/net/src/tls_tcp/openssl.rs
+++ b/src/net/src/tls_tcp/openssl.rs
@@ -50,8 +50,9 @@ impl TlsTcpStream {
             let ptr = self.inner.ssl().as_ptr();
             let ret = unsafe { openssl_sys::SSL_do_handshake(ptr) };
             if ret > 0 {
-                #[cfg(feature = "metrics")]
-                STREAM_HANDSHAKE.increment();
+                metrics! {
+                    STREAM_HANDSHAKE.increment();
+                }
 
                 self.state = TlsState::Negotiated;
 
@@ -63,8 +64,7 @@ impl TlsTcpStream {
                         Err(Error::from(ErrorKind::WouldBlock))
                     }
                     _ => {
-                        #[cfg(feature = "metrics")]
-                        {
+                        metrics! {
                             STREAM_HANDSHAKE.increment();
                             STREAM_HANDSHAKE_EX.increment();
                         }

--- a/src/net/src/tls_tcp/openssl.rs
+++ b/src/net/src/tls_tcp/openssl.rs
@@ -50,7 +50,7 @@ impl TlsTcpStream {
             let ptr = self.inner.ssl().as_ptr();
             let ret = unsafe { openssl_sys::SSL_do_handshake(ptr) };
             if ret > 0 {
-                metrics! {
+                metric! {
                     STREAM_HANDSHAKE.increment();
                 }
 
@@ -64,7 +64,7 @@ impl TlsTcpStream {
                         Err(Error::from(ErrorKind::WouldBlock))
                     }
                     _ => {
-                        metrics! {
+                        metric! {
                             STREAM_HANDSHAKE.increment();
                             STREAM_HANDSHAKE_EX.increment();
                         }

--- a/src/proxy/momento/Cargo.toml
+++ b/src/proxy/momento/Cargo.toml
@@ -19,7 +19,7 @@ libc = { workspace = true }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
 momento = "0.32.0"
-pelikan-net = { workspace = true }
+pelikan-net = { workspace = true, features = ["metrics"] }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-memcache = { path = "../../protocol/memcache" }
 protocol-resp = { path = "../../protocol/resp" }

--- a/src/proxy/ping/Cargo.toml
+++ b/src/proxy/ping/Cargo.toml
@@ -25,5 +25,5 @@ common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
-proxy = { path = "../../core/proxy" }
+proxy = { path = "../../core/proxy", features = ["boringssl"] }
 protocol-ping = { path = "../../protocol/ping", features = ["client", "server"] }

--- a/src/server/pingserver/Cargo.toml
+++ b/src/server/pingserver/Cargo.toml
@@ -38,7 +38,7 @@ entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
 protocol-ping = { path = "../../protocol/ping", features = ["server"] }
-server = { path = "../../core/server" }
+server = { path = "../../core/server", features = ["boringssl"] }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/server/rds/Cargo.toml
+++ b/src/server/rds/Cargo.toml
@@ -46,7 +46,7 @@ entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
 protocol-resp = { path = "../../protocol/resp" }
-server = { path = "../../core/server" }
+server = { path = "../../core/server", features = ["boringssl"] }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/server/segcache/Cargo.toml
+++ b/src/server/segcache/Cargo.toml
@@ -46,7 +46,7 @@ entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
 protocol-memcache = { path = "../../protocol/memcache" }
-server = { path = "../../core/server" }
+server = { path = "../../core/server", features = ["boringssl"] }
 
 [dev-dependencies]
 criterion = "0.5.1"


### PR DESCRIPTION
Changes the way metrics are included in pelikan-net, moving them behind a feature flag to make them opt-in.