### PR TITLE
fix: treat memcached request ttl as seconds

### DIFF
--- a/src/proxy/momento/src/protocol/memcache/set.rs
+++ b/src/proxy/momento/src/protocol/memcache/set.rs
@@ -30,7 +30,7 @@ pub async fn set(
     let ttl = request
         .ttl()
         .get()
-        .map(|ttl| Duration::from_millis(ttl.max(1) as u64));
+        .map(|ttl| Duration::from_secs(ttl.max(1) as u64));
 
     match timeout(
         Duration::from_millis(200),


### PR DESCRIPTION
I was seeing a 0 % hit rate when testing against Momento because the items were expiring immediately due to wrong ttl.