### PR TITLE
fix ci: cargo audit

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -86,8 +86,6 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-audit
-          version: '0.21.0-pre.0'
-          locked: true
       - run: |
           cargo audit
 


### PR DESCRIPTION
CI is failing regularly due to outdated cargo audit version. This change removes the version lock so we use the latest instead.