### PR TITLE
fix(protocol-memcache): emit END on GET misses instead of NOT_FOUND

### DIFF
--- a/src/protocol/memcache/src/text/response/get.rs
+++ b/src/protocol/memcache/src/text/response/get.rs
@@ -70,3 +70,57 @@ impl TextProtocol {
         Ok(response.compose(buffer))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+
+    use super::*;
+
+    #[test]
+    fn text_get_with_some_hit_doesnt_emit_end() {
+        // Simulate a get request and response with some keys that hit and some that miss.
+        let request = Get {
+            key: true,
+            opaque: None,
+            keys: vec![
+                b"key".to_vec().into_boxed_slice(),
+                b"missing_key".to_vec().into_boxed_slice(),
+            ]
+            .into_boxed_slice(),
+            cas: false,
+        };
+
+        let resp = Response::values(vec![Value::new(b"key", 0, None, b"val")].into_boxed_slice());
+
+        // Verify that the response is composed correctly.
+        let mut buffer = BytesMut::new();
+        let text_protocol = TextProtocol::default();
+        text_protocol
+            .compose_get_response(&request, &resp, &mut buffer)
+            .unwrap();
+
+        assert_eq!(&buffer[..], b"VALUE key 0 3\r\nval\r\nEND\r\n");
+    }
+
+    #[test]
+    fn text_get_miss_emits_end() {
+        // Simulate a get request and response with all keys missing.
+        let request = Get {
+            key: true,
+            opaque: None,
+            keys: vec![b"missing".to_vec().into_boxed_slice()].into_boxed_slice(),
+            cas: false,
+        };
+        let response = Response::not_found(false);
+
+        // Verify that the response is composed correctly.
+        let mut buffer = BytesMut::new();
+        let text_protocol = TextProtocol::default();
+        text_protocol
+            .compose_get_response(&request, &response, &mut buffer)
+            .unwrap();
+
+        assert_eq!(&buffer[..], b"END\r\n");
+    }
+}

--- a/src/protocol/memcache/src/text/response/get.rs
+++ b/src/protocol/memcache/src/text/response/get.rs
@@ -57,6 +57,16 @@ impl TextProtocol {
             }
         }
 
+        // For text GETs where all keys miss, emit just "END\r\n" by
+        // composing an empty Values; otherwise forward the original
+        // response.
+        // The binary protocol uses the `NotFound` directly.
+        if let Response::NotFound(_) = response {
+            let empty = Values {
+                values: Vec::new().into(),
+            };
+            return Ok(Response::Values(empty).compose(buffer));
+        }
         Ok(response.compose(buffer))
     }
 }


### PR DESCRIPTION
### What’s changed

After refactoring to support the memcached binary protocol, GET misses in text mode were being rendered as `NOT_FOUND\r\n` (via `Response::NotFound`), but per the ASCII spec they must emit `END\r\n` (an empty value set). This patch:

- In `TextProtocol::compose_get_response`, intercepts `Response::NotFound` and replaces it with a zero-length `Values` so that `compose()` writes exactly `END\r\n`.
- Leaves the binary branch untouched: GET misses still serialize as the correct `KEY_NOT_FOUND` status frame.

### Why

The text protocol never uses `NOT_FOUND` for GET; that token is only for operations like `delete` or `cas`. ASCII clients (telnet, spymemcached in text mode, etc.) expect `END` to terminate a miss, so returning `NOT_FOUND` was breaking them.

### Testing
- Added unit tests verifying that a text-mode GET miss produces exactly `END\r\n`.
- Manual verification via `telnet localhost 11211`:
  ```text
  get missing_key
  END