### PR TITLE
Fix Buffer memory deallocation

### DIFF
--- a/src/session/src/buffer.rs
+++ b/src/session/src/buffer.rs
@@ -168,6 +168,10 @@ impl Buffer {
 
 impl Drop for Buffer {
     fn drop(&mut self) {
+        let layout = Layout::array::<u8>(self.cap).unwrap();
+        unsafe {
+            dealloc(self.ptr, layout);
+        }
         SESSION_BUFFER_BYTE.sub(self.cap as _);
     }
 }


### PR DESCRIPTION
## Summary
- release buffer memory in `Drop` implementation before adjusting metrics

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_b_683f4c998fec832abaa1a26225c5ae6f