### PR TITLE
fix ci fuzz test workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           export CARGO_TARGET_DIR=$(pwd)/target
 
-          for target in protocol/admin protocol/memcache protocol/ping protocol/thrift storage/segcache; do
+          for target in protocol/admin protocol/memcache protocol/ping storage/segcache; do
             cd src/$target
             echo "::group::Building $target"
             cargo fuzz build


### PR DESCRIPTION
Fixes ci fuzz test workflow (broken by #153) by removing the thrift protocol test from the workflow.