### PR TITLE
feat: add log rotation via logroller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +309,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -588,6 +625,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +746,30 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "id-arena"
@@ -824,10 +895,23 @@ version = "0.3.2"
 dependencies = [
  "config",
  "log",
+ "logroller",
  "tracing",
  "tracing-appender",
  "tracing-log",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "logroller"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83db12bbf439ebe64c0b0e4402f435b6f866db498fc1ae17e1b5d1a01625e2be"
+dependencies = [
+ "chrono",
+ "flate2",
+ "regex",
+ "thiserror 1.0.58",
 ]
 
 [[package]]
@@ -903,6 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1718,6 +1803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,10 +2329,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ datatier = { path = "./src/storage/datatier", version = "0.1.0" }
 httparse = "1.10.1"
 libc = "0.2.183"
 log = "0.4.29"
+logroller = "0.1"
 memmap2 = "0.9.10"
 metriken = "0.7.0"
 metrohash = "1.0.7"

--- a/config/pingproxy.toml
+++ b/config/pingproxy.toml
@@ -51,21 +51,18 @@ endpoints = [
 log_level = "info"
 # optionally, log to the file below instead of standard out
 # log_file = "pingproxy.log"
-# backup file name for use with log rotation
-log_backup = "pingproxy.log.old"
-# trigger log rotation when the file grows beyond this size (in bytes). Set this
-# option to '0' to disable log rotation.
-log_max_size = 1073741824
-
+# rotation interval: none, minutely, hourly, daily
+# log_rotation_interval = "daily"
+# max number of rotated log files to keep
+# log_max_keep_files = 7
 
 [klog]
 # optionally, log commands to the file below
 # file = "pingproxy.cmd"
-# backup file name for use with log rotation
-backup = "pingproxy.cmd.old"
-# trigger log rotation when the file grows beyond this size (in bytes). Set this
-# option to '0' to disable log rotation.
-max_size = 1073741824
+# trigger log rotation when the file grows beyond this size (in bytes)
+max_size = "1GB"
+# max number of rotated log files to keep
+# max_keep_files = 3
 # specify the sampling ratio, 1 in N commands will be logged. Setting to '0'
 # will disable command logging.
 sample = 100

--- a/config/pingserver.toml
+++ b/config/pingserver.toml
@@ -57,20 +57,18 @@ threads = 1
 log_level = "info"
 # optionally, log to the file below instead of standard out
 # log_file = "pingserver.log"
-# backup file name for use with log rotation
-log_backup = "pingserver.log.old"
-# trigger log rotation when the file grows beyond this size (in bytes). Set this
-# option to '0' to disable log rotation.
-log_max_size = 1073741824
+# rotation interval: none, minutely, hourly, daily
+# log_rotation_interval = "daily"
+# max number of rotated log files to keep
+# log_max_keep_files = 7
 
 [klog]
 # optionally, log commands to the file below
 # file = "pingserver.cmd"
-# backup file name for use with log rotation
-backup = "pingserver.cmd.old"
-# trigger log rotation when the file grows beyond this size (in bytes). Set this
-# option to '0' to disable log rotation.
-max_size = 1073741824
+# trigger log rotation when the file grows beyond this size (in bytes)
+max_size = "1GB"
+# max number of rotated log files to keep
+# max_keep_files = 3
 # specify the sampling ratio, 1 in N commands will be logged. Setting to '0'
 # will disable command logging.
 sample = 100

--- a/config/rds.toml
+++ b/config/rds.toml
@@ -35,10 +35,10 @@ threads = 1
 [seg]
 # hash power adjusts how many items can be held in the hashtable
 hash_power = 22
-# total bytes to use for item storage - 4GiB
-heap_size = 4294967296
-# size of each segment in bytes - 1MiB
-segment_size = 1048576
+# total bytes to use for item storage
+heap_size = "4GB"
+# size of each segment
+segment_size = "1MB"
 # number of segments for a non-evict compaction
 compact_target = 2
 # number of segments to merge in one merge eviction pass
@@ -60,20 +60,18 @@ time_type = "Delta"
 log_level = "info"
 # optionally, log to the file below instead of standard out
 # log_file = "rds.log"
-# backup file name for use with log rotation
-log_backup = "rds.log.old"
-# trigger log rotation when the file grows beyond this size (in bytes). Set this
-# option to '0' to disable log rotation.
-log_max_size = 1073741824
+# rotation interval: none, minutely, hourly, daily
+# log_rotation_interval = "daily"
+# max number of rotated log files to keep
+# log_max_keep_files = 7
 
 [klog]
 # optionally, log commands to the file below
 # file = "rds.cmd"
-# backup file name for use with log rotation
-backup = "rds.cmd.old"
-# trigger log rotation when the file grows beyond this size (in bytes). Set this
-# option to '0' to disable log rotation.
-max_size = 1073741824
+# trigger log rotation when the file grows beyond this size (in bytes)
+max_size = "1GB"
+# max number of rotated log files to keep
+# max_keep_files = 3
 # specify the sampling ratio, 1 in N commands will be logged. Setting to '0'
 # will disable command logging.
 sample = 100

--- a/config/segcache.toml
+++ b/config/segcache.toml
@@ -35,10 +35,10 @@ threads = 1
 [seg]
 # hash power adjusts how many items can be held in the hashtable
 hash_power = 22
-# total bytes to use for item storage - 4GiB
-heap_size = 4294967296
-# size of each segment in bytes - 1MiB
-segment_size = 1048576
+# total bytes to use for item storage
+heap_size = "4GB"
+# size of each segment
+segment_size = "1MB"
 # number of segments for a non-evict compaction
 compact_target = 2
 # number of segments to merge in one merge eviction pass
@@ -60,20 +60,18 @@ time_type = "Memcache"
 log_level = "info"
 # optionally, log to the file below instead of standard out
 # log_file = "segcache.log"
-# backup file name for use with log rotation
-log_backup = "segcache.log.old"
-# trigger log rotation when the file grows beyond this size (in bytes). Set this
-# option to '0' to disable log rotation.
-log_max_size = 1073741824
+# rotation interval: none, minutely, hourly, daily
+# log_rotation_interval = "daily"
+# max number of rotated log files to keep
+# log_max_keep_files = 7
 
 [klog]
 # optionally, log commands to the file below
 # file = "segcache.cmd"
-# backup file name for use with log rotation
-backup = "segcache.cmd.old"
-# trigger log rotation when the file grows beyond this size (in bytes). Set this
-# option to '0' to disable log rotation.
-max_size = 1073741824
+# trigger log rotation when the file grows beyond this size (in bytes)
+max_size = "1GB"
+# max number of rotated log files to keep
+# max_keep_files = 3
 # specify the sampling ratio, 1 in N commands will be logged. Setting to '0'
 # will disable command logging.
 sample = 100

--- a/config/twemcache-tls.toml
+++ b/config/twemcache-tls.toml
@@ -24,10 +24,10 @@ threads = 1
 [segcache]
 # hash power adjusts how many items can be held in the hashtable
 hash_power = 16
-# total bytes to use for item storage - 4GiB
-heap_size = 4294967296
-# size of each segment in bytes - 1MiB
-segment_size = 1048576
+# total bytes to use for item storage
+heap_size = "4GB"
+# size of each segment
+segment_size = "1MB"
 # eviction policy is segment random, similar to slab random for Twemcache
 eviction = "Random"
 

--- a/src/config/src/buf.rs
+++ b/src/config/src/buf.rs
@@ -23,6 +23,7 @@ fn poolsize() -> usize {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Buf {
     #[serde(default = "size")]
+    #[serde(with = "crate::human_size::as_usize")]
     size: usize,
     #[serde(default = "poolsize")]
     poolsize: usize,

--- a/src/config/src/debug.rs
+++ b/src/config/src/debug.rs
@@ -11,6 +11,8 @@ const LOG_LEVEL: Level = Level::Info;
 const LOG_FILE: Option<String> = None;
 const LOG_BACKUP: Option<String> = None;
 const LOG_MAX_SIZE: u64 = GB as u64;
+const LOG_MAX_KEEP_FILES: u64 = 7;
+const LOG_ROTATION_INTERVAL: LogRotationInterval = LogRotationInterval::Daily;
 const LOG_QUEUE_DEPTH: usize = 4096;
 const LOG_SINGLE_MESSAGE_SIZE: usize = KB;
 
@@ -29,6 +31,14 @@ fn log_backup() -> Option<String> {
 
 fn log_max_size() -> u64 {
     LOG_MAX_SIZE
+}
+
+fn log_max_keep_files() -> u64 {
+    LOG_MAX_KEEP_FILES
+}
+
+fn log_rotation_interval() -> LogRotationInterval {
+    LOG_ROTATION_INTERVAL
 }
 
 fn log_queue_depth() -> usize {
@@ -51,10 +61,23 @@ pub struct Debug {
     log_backup: Option<String>,
     #[serde(default = "log_max_size")]
     log_max_size: u64,
+    #[serde(default = "log_max_keep_files")]
+    log_max_keep_files: u64,
+    #[serde(default = "log_rotation_interval")]
+    log_rotation_interval: LogRotationInterval,
     #[serde(default = "log_queue_depth")]
     log_queue_depth: usize,
     #[serde(default = "log_single_message_size")]
     log_single_message_size: usize,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogRotationInterval {
+    None,
+    Minutely,
+    Hourly,
+    Daily,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -90,6 +113,14 @@ impl Debug {
         self.log_max_size
     }
 
+    pub fn log_max_keep_files(&self) -> u64 {
+        self.log_max_keep_files
+    }
+
+    pub fn log_rotation_interval(&self) -> LogRotationInterval {
+        self.log_rotation_interval
+    }
+
     pub fn log_queue_depth(&self) -> usize {
         self.log_queue_depth
     }
@@ -107,6 +138,8 @@ impl Default for Debug {
             log_file: log_file(),
             log_backup: log_backup(),
             log_max_size: log_max_size(),
+            log_max_keep_files: log_max_keep_files(),
+            log_rotation_interval: log_rotation_interval(),
             log_queue_depth: log_queue_depth(),
             log_single_message_size: log_single_message_size(),
         }

--- a/src/config/src/debug.rs
+++ b/src/config/src/debug.rs
@@ -2,19 +2,14 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::units::*;
 use log::Level;
 use serde::{Deserialize, Serialize};
 
 // constants to define default values
 const LOG_LEVEL: Level = Level::Info;
 const LOG_FILE: Option<String> = None;
-const LOG_BACKUP: Option<String> = None;
-const LOG_MAX_SIZE: u64 = GB as u64;
 const LOG_MAX_KEEP_FILES: u64 = 7;
 const LOG_ROTATION_INTERVAL: LogRotationInterval = LogRotationInterval::Daily;
-const LOG_QUEUE_DEPTH: usize = 4096;
-const LOG_SINGLE_MESSAGE_SIZE: usize = KB;
 
 // helper functions
 fn log_level() -> Level {
@@ -25,28 +20,12 @@ fn log_file() -> Option<String> {
     LOG_FILE
 }
 
-fn log_backup() -> Option<String> {
-    LOG_BACKUP
-}
-
-fn log_max_size() -> u64 {
-    LOG_MAX_SIZE
-}
-
 fn log_max_keep_files() -> u64 {
     LOG_MAX_KEEP_FILES
 }
 
 fn log_rotation_interval() -> LogRotationInterval {
     LOG_ROTATION_INTERVAL
-}
-
-fn log_queue_depth() -> usize {
-    LOG_QUEUE_DEPTH
-}
-
-fn log_single_message_size() -> usize {
-    LOG_SINGLE_MESSAGE_SIZE
 }
 
 // struct definitions
@@ -57,18 +36,10 @@ pub struct Debug {
     log_level: Level,
     #[serde(default = "log_file")]
     log_file: Option<String>,
-    #[serde(default = "log_backup")]
-    log_backup: Option<String>,
-    #[serde(default = "log_max_size")]
-    log_max_size: u64,
     #[serde(default = "log_max_keep_files")]
     log_max_keep_files: u64,
     #[serde(default = "log_rotation_interval")]
     log_rotation_interval: LogRotationInterval,
-    #[serde(default = "log_queue_depth")]
-    log_queue_depth: usize,
-    #[serde(default = "log_single_message_size")]
-    log_single_message_size: usize,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -102,31 +73,12 @@ impl Debug {
         self.log_file.clone()
     }
 
-    pub fn log_backup(&self) -> Option<String> {
-        match &self.log_backup {
-            Some(path) => Some(path.clone()),
-            None => self.log_file.as_ref().map(|path| format!("{path}.old")),
-        }
-    }
-
-    pub fn log_max_size(&self) -> u64 {
-        self.log_max_size
-    }
-
     pub fn log_max_keep_files(&self) -> u64 {
         self.log_max_keep_files
     }
 
     pub fn log_rotation_interval(&self) -> LogRotationInterval {
         self.log_rotation_interval
-    }
-
-    pub fn log_queue_depth(&self) -> usize {
-        self.log_queue_depth
-    }
-
-    pub fn log_single_message_size(&self) -> usize {
-        self.log_single_message_size
     }
 }
 
@@ -136,12 +88,8 @@ impl Default for Debug {
         Self {
             log_level: log_level(),
             log_file: log_file(),
-            log_backup: log_backup(),
-            log_max_size: log_max_size(),
             log_max_keep_files: log_max_keep_files(),
             log_rotation_interval: log_rotation_interval(),
-            log_queue_depth: log_queue_depth(),
-            log_single_message_size: log_single_message_size(),
         }
     }
 }

--- a/src/config/src/human_size.rs
+++ b/src/config/src/human_size.rs
@@ -1,0 +1,164 @@
+//! Deserialize byte sizes from either integers or human-readable strings.
+//!
+//! Supports GB, MB, KB suffixes (case-insensitive) or raw integer bytes.
+//! Values must be whole numbers (e.g. "1GB", "512MB", "100KB", 4096).
+//!
+//! Three submodules for different target types:
+//! - `as_u64` — for u64 fields (e.g. klog max_size)
+//! - `as_usize` — for usize fields (e.g. seg heap_size)
+//! - `as_i32` — for i32 fields with range validation (e.g. seg segment_size)
+
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+const KB: u64 = 1024;
+const MB: u64 = 1024 * KB;
+const GB: u64 = 1024 * MB;
+
+fn parse_size(s: &str) -> Result<u64, String> {
+    let s = s.trim();
+    let upper = s.to_uppercase();
+
+    let (num_str, multiplier) = if let Some(n) = upper.strip_suffix("GB") {
+        (n, GB)
+    } else if let Some(n) = upper.strip_suffix("MB") {
+        (n, MB)
+    } else if let Some(n) = upper.strip_suffix("KB") {
+        (n, KB)
+    } else {
+        return s
+            .parse::<u64>()
+            .map_err(|_| format!("invalid size: {s} (expected integer or <N>KB/MB/GB)"));
+    };
+
+    num_str
+        .trim()
+        .parse::<u64>()
+        .map(|n| n * multiplier)
+        .map_err(|_| format!("invalid size: {s} (expected integer before unit)"))
+}
+
+fn deserialize_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum SizeValue {
+        Num(u64),
+        Str(String),
+    }
+
+    match SizeValue::deserialize(deserializer)? {
+        SizeValue::Num(n) => Ok(n),
+        SizeValue::Str(s) => parse_size(&s).map_err(serde::de::Error::custom),
+    }
+}
+
+/// For `#[serde(with = "crate::human_size::as_u64")]` on u64 fields.
+pub mod as_u64 {
+    use super::*;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_u64(deserializer)
+    }
+
+    pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value.serialize(serializer)
+    }
+}
+
+/// For `#[serde(with = "crate::human_size::as_usize")]` on usize fields.
+pub mod as_usize {
+    use super::*;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<usize, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = deserialize_u64(deserializer)?;
+        usize::try_from(v)
+            .map_err(|_| serde::de::Error::custom(format!("size {v} exceeds usize::MAX")))
+    }
+
+    pub fn serialize<S>(value: &usize, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value.serialize(serializer)
+    }
+}
+
+/// For `#[serde(with = "crate::human_size::as_i32")]` on i32 fields.
+/// Validates that the parsed value fits within i32 range.
+pub mod as_i32 {
+    use super::*;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<i32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = deserialize_u64(deserializer)?;
+        i32::try_from(v).map_err(|_| {
+            serde::de::Error::custom(format!("size {v} exceeds i32::MAX ({})", i32::MAX))
+        })
+    }
+
+    pub fn serialize<S>(value: &i32, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_gb() {
+        assert_eq!(parse_size("1GB").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_size("2gb").unwrap(), 2 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_mb() {
+        assert_eq!(parse_size("512MB").unwrap(), 512 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_kb() {
+        assert_eq!(parse_size("100KB").unwrap(), 100 * 1024);
+    }
+
+    #[test]
+    fn parse_raw_number() {
+        assert_eq!(parse_size("4096").unwrap(), 4096);
+    }
+
+    #[test]
+    fn parse_with_spaces() {
+        assert_eq!(parse_size(" 1 GB ").unwrap(), 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_invalid() {
+        assert!(parse_size("abc").is_err());
+        assert!(parse_size("1TB").is_err());
+        assert!(parse_size("1.5GB").is_err());
+    }
+
+    #[test]
+    fn i32_overflow() {
+        // 2GB = 2147483648, which is i32::MAX + 1
+        assert!(parse_size("2GB").unwrap() > i32::MAX as u64);
+        // 1GB fits
+        assert!(parse_size("1GB").unwrap() <= i32::MAX as u64);
+    }
+}

--- a/src/config/src/klog.rs
+++ b/src/config/src/klog.rs
@@ -12,26 +12,14 @@ use serde::{Deserialize, Serialize};
 // log to the file path
 const FILE: Option<String> = None;
 
-// log will rotate to the given backup path
-const BACKUP: Option<String> = None;
-
-// flush interval in milliseconds
-const INTERVAL: usize = 100;
-
 // max log size before rotate in bytes
 const MAX_SIZE: u64 = GB as u64;
-
-// logger queue depth
-const QUEUE_DEPTH: usize = 4096;
 
 // log 1 in every N commands
 const SAMPLE: usize = 100;
 
 // max number of rotated log files to keep
 const MAX_KEEP_FILES: u64 = 3;
-
-// single message buffer size in bytes
-const SINGLE_MESSAGE_SIZE: usize = KB;
 
 ////////////////////////////////////////////////////////////////////////////////
 // helper functions
@@ -41,20 +29,8 @@ fn file() -> Option<String> {
     FILE
 }
 
-fn backup() -> Option<String> {
-    BACKUP
-}
-
-fn interval() -> usize {
-    INTERVAL
-}
-
 fn max_size() -> u64 {
     MAX_SIZE
-}
-
-fn queue_depth() -> usize {
-    QUEUE_DEPTH
 }
 
 fn sample() -> usize {
@@ -65,32 +41,21 @@ fn max_keep_files() -> u64 {
     MAX_KEEP_FILES
 }
 
-fn single_message_size() -> usize {
-    SINGLE_MESSAGE_SIZE
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // struct definitions
 ////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Klog {
-    #[serde(default = "backup")]
-    backup: Option<String>,
     #[serde(default = "file")]
     file: Option<String>,
-    #[serde(default = "interval")]
-    interval: usize,
     #[serde(default = "max_size")]
+    #[serde(with = "crate::human_size::as_u64")]
     max_size: u64,
     #[serde(default = "max_keep_files")]
     max_keep_files: u64,
-    #[serde(default = "queue_depth")]
-    queue_depth: usize,
     #[serde(default = "sample")]
     sample: usize,
-    #[serde(default = "single_message_size")]
-    single_message_size: usize,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -102,23 +67,8 @@ impl Klog {
         self.file.clone()
     }
 
-    pub fn backup(&self) -> Option<String> {
-        match &self.backup {
-            Some(path) => Some(path.clone()),
-            None => self.file.as_ref().map(|path| format!("{path}.old")),
-        }
-    }
-
-    pub fn interval(&self) -> usize {
-        self.interval
-    }
-
     pub fn max_size(&self) -> u64 {
         self.max_size
-    }
-
-    pub fn queue_depth(&self) -> usize {
-        self.queue_depth
     }
 
     pub fn sample(&self) -> usize {
@@ -128,10 +78,6 @@ impl Klog {
     pub fn max_keep_files(&self) -> u64 {
         self.max_keep_files
     }
-
-    pub fn single_message_size(&self) -> usize {
-        self.single_message_size
-    }
 }
 
 // trait implementations
@@ -139,13 +85,9 @@ impl Default for Klog {
     fn default() -> Self {
         Self {
             file: file(),
-            backup: backup(),
-            interval: interval(),
             max_size: max_size(),
             max_keep_files: max_keep_files(),
-            queue_depth: queue_depth(),
             sample: sample(),
-            single_message_size: single_message_size(),
         }
     }
 }

--- a/src/config/src/klog.rs
+++ b/src/config/src/klog.rs
@@ -27,6 +27,9 @@ const QUEUE_DEPTH: usize = 4096;
 // log 1 in every N commands
 const SAMPLE: usize = 100;
 
+// max number of rotated log files to keep
+const MAX_KEEP_FILES: u64 = 3;
+
 // single message buffer size in bytes
 const SINGLE_MESSAGE_SIZE: usize = KB;
 
@@ -58,6 +61,10 @@ fn sample() -> usize {
     SAMPLE
 }
 
+fn max_keep_files() -> u64 {
+    MAX_KEEP_FILES
+}
+
 fn single_message_size() -> usize {
     SINGLE_MESSAGE_SIZE
 }
@@ -76,6 +83,8 @@ pub struct Klog {
     interval: usize,
     #[serde(default = "max_size")]
     max_size: u64,
+    #[serde(default = "max_keep_files")]
+    max_keep_files: u64,
     #[serde(default = "queue_depth")]
     queue_depth: usize,
     #[serde(default = "sample")]
@@ -116,6 +125,10 @@ impl Klog {
         self.sample
     }
 
+    pub fn max_keep_files(&self) -> u64 {
+        self.max_keep_files
+    }
+
     pub fn single_message_size(&self) -> usize {
         self.single_message_size
     }
@@ -129,6 +142,7 @@ impl Default for Klog {
             backup: backup(),
             interval: interval(),
             max_size: max_size(),
+            max_keep_files: max_keep_files(),
             queue_depth: queue_depth(),
             sample: sample(),
             single_message_size: single_message_size(),

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -23,6 +23,7 @@ mod stats_log;
 mod tcp;
 pub mod time;
 
+mod human_size;
 mod tls;
 mod units;
 mod worker;

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -31,7 +31,7 @@ pub use admin::{Admin, AdminConfig};
 pub use array::ArrayConfig;
 pub use buf::{Buf, BufConfig};
 pub use dbuf::DbufConfig;
-pub use debug::{Debug, DebugConfig};
+pub use debug::{Debug, DebugConfig, LogRotationInterval};
 pub use klog::{Klog, KlogConfig};
 pub use pingproxy::PingproxyConfig;
 pub use pingserver::PingserverConfig;

--- a/src/config/src/seg.rs
+++ b/src/config/src/seg.rs
@@ -83,8 +83,10 @@ pub struct Seg {
     #[serde(default = "overflow_factor")]
     overflow_factor: f64,
     #[serde(default = "heap_size")]
+    #[serde(with = "crate::human_size::as_usize")]
     heap_size: usize,
     #[serde(default = "segment_size")]
+    #[serde(with = "crate::human_size::as_i32")]
     segment_size: i32,
     #[serde(default = "eviction")]
     eviction: Eviction,

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 [dependencies]
 config = { path = "../config", default-features = false }
 log = { workspace = true }
+logroller = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-log = { workspace = true }

--- a/src/logger/src/lib.rs
+++ b/src/logger/src/lib.rs
@@ -8,7 +8,8 @@
 //! existing `log` crate callsites through `tracing-log`. The `klog!` macro
 //! provides callsite-sampled command logging.
 
-use config::{DebugConfig, KlogConfig};
+use config::{DebugConfig, KlogConfig, LogRotationInterval};
+use logroller::{Compression, LogRollerBuilder, Rotation, RotationAge, RotationSize};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
@@ -93,31 +94,63 @@ pub fn configure_logging<T: DebugConfig + KlogConfig>(config: &T) -> LogDrain {
         log::Level::Trace => tracing::Level::TRACE,
     };
 
-    // Set up the debug log writer (file or stdout)
+    // Set up the debug log writer (file with rotation, or stdout)
     let (debug_writer, debug_guard) = if let Some(file) = debug_config.log_file() {
-        let dir = std::path::Path::new(&file)
-            .parent()
-            .unwrap_or(std::path::Path::new("."));
-        let filename = std::path::Path::new(&file)
+        let path = std::path::Path::new(&file);
+        let dir = path.parent().unwrap_or(std::path::Path::new("."));
+        let filename = path
             .file_name()
-            .unwrap_or(std::ffi::OsStr::new("pelikan.log"));
-        let file_appender = tracing_appender::rolling::never(dir, filename);
-        tracing_appender::non_blocking(file_appender)
+            .map(std::path::Path::new)
+            .unwrap_or(std::path::Path::new("pelikan.log"));
+        match debug_config.log_rotation_interval() {
+            LogRotationInterval::None => {
+                // No rotation — user manages rotation externally (e.g. logrotate)
+                let file_appender = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&file)
+                    .expect("failed to open debug log file");
+                tracing_appender::non_blocking(file_appender)
+            }
+            interval => {
+                let rotation_age = match interval {
+                    LogRotationInterval::Minutely => RotationAge::Minutely,
+                    LogRotationInterval::Hourly => RotationAge::Hourly,
+                    LogRotationInterval::Daily => RotationAge::Daily,
+                    LogRotationInterval::None => unreachable!(),
+                };
+                let file_appender = LogRollerBuilder::new(dir, filename)
+                    .rotation(Rotation::AgeBased(rotation_age))
+                    .max_keep_files(debug_config.log_max_keep_files())
+                    .compression(Compression::Gzip)
+                    .graceful_shutdown(true)
+                    .build()
+                    .expect("failed to create debug log appender");
+                tracing_appender::non_blocking(file_appender)
+            }
+        }
     } else {
         tracing_appender::non_blocking(std::io::stdout())
     };
 
     let mut guards = vec![debug_guard];
 
-    // Set up the klog writer if configured
+    // Set up the klog writer with size-based rotation if configured
     let klog_writer_and_guard = klog_config.file().map(|file| {
-        let dir = std::path::Path::new(&file)
-            .parent()
-            .unwrap_or(std::path::Path::new("."));
-        let filename = std::path::Path::new(&file)
+        let path = std::path::Path::new(&file);
+        let dir = path.parent().unwrap_or(std::path::Path::new("."));
+        let filename = path
             .file_name()
-            .unwrap_or(std::ffi::OsStr::new("klog"));
-        let file_appender = tracing_appender::rolling::never(dir, filename);
+            .map(std::path::Path::new)
+            .unwrap_or(std::path::Path::new("klog"));
+        let max_bytes = klog_config.max_size();
+        let file_appender = LogRollerBuilder::new(dir, filename)
+            .rotation(Rotation::SizeBased(RotationSize::Bytes(max_bytes)))
+            .max_keep_files(klog_config.max_keep_files())
+            .compression(Compression::Gzip)
+            .graceful_shutdown(true)
+            .build()
+            .expect("failed to create klog appender");
         tracing_appender::non_blocking(file_appender)
     });
 


### PR DESCRIPTION
## Summary
- Replace non-rotating `tracing-appender` with `logroller` for both debug and klog writers
- Debug log: age-based rotation (daily default), configurable interval (`minutely`/`hourly`/`daily`/`none`), 7 rotated files kept by default
- Klog: size-based rotation using existing `max_size` config, 3 rotated files kept by default
- Both loggers use gzip compression on rotated files and graceful shutdown for clean flush on exit
- Setting `log_rotation_interval = "none"` disables rotation entirely for external management (e.g. system `logrotate`)
- Remove dead config fields from ringlog era (`log_backup`, `log_max_size`, `log_queue_depth`, `log_single_message_size`, `backup`, `interval`, `queue_depth`, `single_message_size`)
- Add `human_size` serde module for human-readable byte sizes (`"4GB"`, `"1MB"`, `"16KB"`) with `u64`, `usize`, and `i32` target types
- Wire up human-readable sizes for klog `max_size`, seg `heap_size`/`segment_size`, and buf `size`

## Config changes

### New fields
| Field | Section | Default | Description |
|-------|---------|---------|-------------|
| `log_max_keep_files` | `[debug]` | 7 | Max rotated debug log files to retain |
| `log_rotation_interval` | `[debug]` | `daily` | Rotation interval (`none`/`minutely`/`hourly`/`daily`) |
| `max_keep_files` | `[klog]` | 3 | Max rotated klog files to retain |

### Removed fields
| Field | Section | Reason |
|-------|---------|--------|
| `log_backup` | `[debug]` | Replaced by logroller rotation |
| `log_max_size` | `[debug]` | Debug log uses age-based rotation |
| `log_queue_depth` | `[debug]` | Unused since tracing migration |
| `log_single_message_size` | `[debug]` | Unused since tracing migration |
| `backup` | `[klog]` | Replaced by logroller rotation |
| `interval` | `[klog]` | Unused since tracing migration |
| `queue_depth` | `[klog]` | Unused since tracing migration |
| `single_message_size` | `[klog]` | Unused since tracing migration |

### Human-readable sizes
Byte-size fields now accept strings like `"4GB"`, `"512MB"`, `"16KB"` in addition to raw integers. Applied to: `max_size`, `heap_size`, `segment_size`, `size` (buf).

## Test plan
- [x] `cargo build --workspace --release` compiles clean
- [x] `cargo clippy --workspace --all-targets --all-features` passes
- [x] `cargo test -p config` — all 9 tests pass
- [x] Manual: debug log rotates at configured interval with gzip compression
- [x] Manual: klog rotates at configured size with gzip compression
- [x] Manual: `log_rotation_interval = "none"` produces plain append-only file
- [x] Manual: human-readable sizes parse correctly in TOML configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)