### PR TITLE
feat: support the version command on the memcache data listener

### DIFF
--- a/docs/superpowers/specs/2026-07-15-memcache-version-command-design.md
+++ b/docs/superpowers/specs/2026-07-15-memcache-version-command-design.md
@@ -1,0 +1,129 @@
+# Design: `version` command on the memcache data listener
+
+**Date:** 2026-07-15
+**Status:** Approved (pending spec review)
+
+## Problem
+
+Real memcached supports a `version` command on its data port (both the ASCII
+text protocol and the binary protocol, opcode `0x0b`). Pelikan's memcache
+protocol implementation does not: the `Request`/`Command` enums in
+`src/protocol/memcache/src/request/mod.rs` have no `Version` variant, so the
+data listener rejects `version` as an unknown command.
+
+`VERSION` currently exists only on the **admin** listener (default port 9999),
+handled in `src/core/admin/src/lib.rs`. This is a memcached-compatibility gap on
+the data plane.
+
+## Goal
+
+Support `version` on the memcache data listener, in both the text and binary
+protocols, replying with the server version in memcached's format.
+
+## Version string source
+
+All workspace crates share `version = "0.3.2"` (`Cargo.toml`
+`[workspace.package]`), so `env!("CARGO_PKG_VERSION")` evaluated in the
+entrystore crate equals what the binary and the admin port report. The handler
+uses that constant directly — no plumbing of a version string down into `Seg` is
+required. Reply format matches memcached: a bare version number, e.g.
+`VERSION 0.3.2\r\n` (text) / body `0.3.2` (binary).
+
+## Design
+
+`version` is an argument-less, storage-independent command. It mirrors how
+`quit` is already handled: parsed into a unit-struct request variant, dispatched
+through `Execute`, and answered in the entrystore handler (like
+`Request::Quit(_) => Response::hangup()`).
+
+### Shared request/response types (`src/protocol/memcache/src/`)
+
+- **`request/version.rs`** (new): `pub struct Version {}` + no-op `Klog` impl —
+  a copy of `request/quit.rs`.
+- **`request/mod.rs`**:
+  - `mod version; pub use version::Version;`
+  - `Request::Version(Version)` variant.
+  - `Command::Version` variant.
+  - `Display` arm → `"version"`.
+  - `Klog` arm → delegate to `Version::klog` (no-op).
+- **`response/version.rs`** (new): `pub struct Version { pub(crate) inner: String }`
+  with a `Compose` impl writing `VERSION <inner>\r\n`, and a `parse` fn for the
+  client side.
+- **`response/mod.rs`**:
+  - `mod version; pub use version::Version as VersionResponse;` (aliased to avoid
+    colliding with the request `Version` re-export in `crate::*`).
+  - `Response::Version(VersionResponse)` variant.
+  - `Response::version<T: ToString>(s: T)` constructor.
+  - `Display` arm → `"VERSION"`.
+  - `Compose` arm → delegate. Not a hangup (`should_hangup` unchanged).
+  - `ResponseType::Version` + `response_type` match on `b"VERSION"` +
+    `response` dispatch arm (client-side round-trip completeness).
+
+### Metrics (`src/protocol/memcache/src/metrics.rs`)
+
+- Add `#[metric(name = "version")] pub static VERSION: Counter = Counter::new();`
+  (before the `test_no_duplicates!()` macro).
+
+### Text protocol (`src/protocol/memcache/src/text/`)
+
+- **`text/request/version.rs`** (new): `parse_version_request` (consume
+  `space0` then `crlf`, increment `VERSION` metric under
+  `#[cfg(feature = "metrics")]`) + `_compose_version_request` writing
+  `version\r\n`. Mirrors `text/request/quit.rs`. Unit test:
+  `version\r\n` → `Request::Version(Version {})`.
+- **`text/request/mod.rs`**: `mod version;`
+- **`text/response/version.rs`** (new): `compose_version_response` +
+  `parse_version_response`. Register in `text/response/mod.rs`.
+- **`text/mod.rs`**:
+  - `parse_command`: `b"version" | b"VERSION" => Command::Version`.
+  - `_parse_request`: `Command::Version` → `parse_version_request` →
+    `Request::Version`.
+  - `_compose_request`: `Request::Version(_)` → `_compose_version_request`.
+  - `_parse_response`: `Request::Version(_)` → `parse_version_response`.
+  - `_compose_response`: `Request::Version(r)` → `compose_version_response`.
+
+### Binary protocol (`src/protocol/memcache/src/binary/`)
+
+- **`Opcode`** (`binary/mod.rs`): add `Version` ↔ `0x0b` in `from_u8`/`to_u8`.
+- **`binary/request/header.rs`**: `RequestHeader::version()` constructor
+  (opcode `Version`, all lengths 0).
+- **`binary/request/version.rs`** (new): `parse_version_request` — validate
+  `key_len == 0`, `extras_len == 0`, `total_body_len == 0`; return
+  `Version {}`. `compose_version_request` writes a bare 24-byte header.
+- **`binary/response/version.rs`** (new): `compose_version_response` — write a
+  `ResponseHeader` (opcode `Version`, status `NoError`, no key/extras,
+  `total_body_len = inner.len()`) followed by the version bytes;
+  `parse_version_response` reads the body back into a `Response::Version`.
+- **`binary/mod.rs`**:
+  - `_parse_request`: `Opcode::Version` → `parse_version_request`.
+  - `_compose_request`: `Request::Version(_)` arm.
+  - `_parse_response`: `Request::Version` + `header.opcode == Version` arm.
+  - `_compose_response`: `Request::Version(_)` arm.
+- Register the two new modules in `binary/request/mod.rs` and
+  `binary/response/mod.rs`.
+
+### Handler (`src/entrystore/src/segcache/memcache.rs`)
+
+- `Request::Version(_) => Response::version(env!("CARGO_PKG_VERSION"))` in the
+  `Execute` match.
+
+## Scope
+
+- **In:** text + binary `version` on the memcache data listener; version metric.
+- **Out:** RESP/`rds` server (separate protocol, no memcached `version`);
+  changing the admin `VERSION` behavior.
+
+## Testing
+
+- **Unit:** text parser test (`version\r\n` → `Request::Version`); binary
+  request parse/compose round-trip; response compose byte assertions (text
+  `VERSION 0.3.2\r\n`; binary header + body).
+- **Integration:** in the segcache server test harness (template:
+  `src/server/segcache/tests/common.rs:346`, which already asserts the admin
+  `VERSION {CARGO_PKG_VERSION}` reply), add a data-port case asserting
+  `version\r\n` → `VERSION {CARGO_PKG_VERSION}\r\n`.
+
+## Approach
+
+TDD — write the failing parser/compose unit tests first, then implement each
+layer (shared types → metrics → text → binary → handler → integration).

--- a/src/entrystore/src/segcache/memcache.rs
+++ b/src/entrystore/src/segcache/memcache.rs
@@ -34,6 +34,7 @@ impl Execute<Request, Response> for Seg {
             Request::Delete(delete) => self.delete(delete),
             Request::FlushAll(flush_all) => self.flush_all(flush_all),
             Request::Quit(quit) => self.quit(quit),
+            Request::Version(_) => Response::version(env!("CARGO_PKG_VERSION")),
         }
     }
 }

--- a/src/protocol/memcache/fuzz/fuzz_targets/memcache_binary.rs
+++ b/src/protocol/memcache/fuzz/fuzz_targets/memcache_binary.rs
@@ -60,6 +60,7 @@ fuzz_target!(|data: &[u8]| {
             }
             Request::FlushAll(_) => {}
             Request::Quit(_) => {}
+            Request::Version(_) => {}
         }
     }
 });

--- a/src/protocol/memcache/fuzz/fuzz_targets/memcache_text.rs
+++ b/src/protocol/memcache/fuzz/fuzz_targets/memcache_text.rs
@@ -69,6 +69,7 @@ fuzz_target!(|data: &[u8]| {
             }
             Request::FlushAll(_) => {}
             Request::Quit(_) => {}
+            Request::Version(_) => {}
         }
     }
 });

--- a/src/protocol/memcache/src/binary/mod.rs
+++ b/src/protocol/memcache/src/binary/mod.rs
@@ -55,6 +55,10 @@ impl BinaryProtocol {
                 let (input, request) = self.parse_delete_request(input, header)?;
                 Ok((input, Request::Delete(request)))
             }
+            Opcode::Version => {
+                let (input, request) = self.parse_version_request(input, header)?;
+                Ok((input, Request::Version(request)))
+            }
             _ => Err(nom::Err::Failure(nom::error::Error::new(
                 input,
                 nom::error::ErrorKind::Tag,
@@ -71,6 +75,7 @@ impl BinaryProtocol {
             Request::Delete(r) => self.compose_delete_request(r, buffer),
             Request::Get(r) => self.compose_get_request(r, buffer),
             Request::Set(r) => self.compose_set_request(r, buffer),
+            Request::Version(r) => self.compose_version_request(r, buffer),
             _ => Err(std::io::Error::other(
                 "request unsupported for binary protocol",
             )),
@@ -121,6 +126,12 @@ impl BinaryProtocol {
                     return Ok((input, response));
                 }
             }
+            Request::Version(request) => {
+                if header.opcode == Opcode::Version {
+                    let (input, response) = self.parse_version_response(request, input, header)?;
+                    return Ok((input, response));
+                }
+            }
             _ => {}
         }
 
@@ -140,6 +151,7 @@ impl BinaryProtocol {
             Request::Delete(request) => self.compose_delete_response(request, response, buffer),
             Request::Get(request) => self.compose_get_response(request, response, buffer),
             Request::Set(request) => self.compose_set_response(request, response, buffer),
+            Request::Version(request) => self.compose_version_response(request, response, buffer),
             _ => {
                 unimplemented!()
             }
@@ -236,6 +248,7 @@ pub enum Opcode {
     Get,
     Set,
     Delete,
+    Version,
 }
 
 impl Opcode {
@@ -244,6 +257,7 @@ impl Opcode {
             0x00 => Opcode::Get,
             0x01 => Opcode::Set,
             0x04 => Opcode::Delete,
+            0x0b => Opcode::Version,
             other => Opcode::Unknown(other),
         }
     }
@@ -254,6 +268,7 @@ impl Opcode {
             Opcode::Get => 0x00,
             Opcode::Set => 0x01,
             Opcode::Delete => 0x04,
+            Opcode::Version => 0x0b,
         }
     }
 }

--- a/src/protocol/memcache/src/binary/mod.rs
+++ b/src/protocol/memcache/src/binary/mod.rs
@@ -108,29 +108,21 @@ impl BinaryProtocol {
         }
 
         match request {
-            Request::Delete(request) => {
-                if header.opcode == Opcode::Delete {
-                    let (input, response) = self.parse_delete_response(request, input, header)?;
-                    return Ok((input, response));
-                }
+            Request::Delete(request) if header.opcode == Opcode::Delete => {
+                let (input, response) = self.parse_delete_response(request, input, header)?;
+                return Ok((input, response));
             }
-            Request::Get(request) => {
-                if header.opcode == Opcode::Get {
-                    let (input, response) = self.parse_get_response(request, input, header)?;
-                    return Ok((input, response));
-                }
+            Request::Get(request) if header.opcode == Opcode::Get => {
+                let (input, response) = self.parse_get_response(request, input, header)?;
+                return Ok((input, response));
             }
-            Request::Set(request) => {
-                if header.opcode == Opcode::Set {
-                    let (input, response) = self.parse_set_response(request, input, header)?;
-                    return Ok((input, response));
-                }
+            Request::Set(request) if header.opcode == Opcode::Set => {
+                let (input, response) = self.parse_set_response(request, input, header)?;
+                return Ok((input, response));
             }
-            Request::Version(request) => {
-                if header.opcode == Opcode::Version {
-                    let (input, response) = self.parse_version_response(request, input, header)?;
-                    return Ok((input, response));
-                }
+            Request::Version(request) if header.opcode == Opcode::Version => {
+                let (input, response) = self.parse_version_response(request, input, header)?;
+                return Ok((input, response));
             }
             _ => {}
         }

--- a/src/protocol/memcache/src/binary/request/header.rs
+++ b/src/protocol/memcache/src/binary/request/header.rs
@@ -123,4 +123,10 @@ impl RequestHeader {
 
         header
     }
+
+    /// Create a header for a `version` request. Version takes no key, value, or
+    /// extras.
+    pub fn version() -> Self {
+        Self::with_opcode(Opcode::Version)
+    }
 }

--- a/src/protocol/memcache/src/binary/request/mod.rs
+++ b/src/protocol/memcache/src/binary/request/mod.rs
@@ -3,6 +3,7 @@ use super::*;
 mod delete;
 mod get;
 mod set;
+mod version;
 
 mod header;
 

--- a/src/protocol/memcache/src/binary/request/version.rs
+++ b/src/protocol/memcache/src/binary/request/version.rs
@@ -1,0 +1,100 @@
+use super::*;
+
+impl BinaryProtocol {
+    #[cfg(feature = "metrics")]
+    pub(crate) fn parse_version_request<'a>(
+        &self,
+        input: &'a [u8],
+        header: RequestHeader,
+    ) -> IResult<&'a [u8], Version> {
+        VERSION.increment();
+        self._parse_version_request(input, header)
+    }
+
+    #[cfg(not(feature = "metrics"))]
+    pub(crate) fn parse_version_request<'a>(
+        &self,
+        input: &'a [u8],
+        header: RequestHeader,
+    ) -> IResult<&'a [u8], Version> {
+        self._parse_version_request(input, header)
+    }
+
+    fn _parse_version_request<'a>(
+        &self,
+        input: &'a [u8],
+        header: RequestHeader,
+    ) -> IResult<&'a [u8], Version> {
+        // version takes no key, value, or extras
+        if header.key_len != 0 || header.extras_len != 0 || header.total_body_len != 0 {
+            return Err(nom::Err::Failure(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Tag,
+            )));
+        }
+
+        Ok((
+            input,
+            Version {
+                opaque: Some(header.opaque),
+            },
+        ))
+    }
+
+    pub(crate) fn compose_version_request(
+        &self,
+        request: &Version,
+        buffer: &mut dyn BufMut,
+    ) -> std::result::Result<usize, std::io::Error> {
+        let mut header = RequestHeader::version();
+        header.opaque = request.opaque.unwrap_or(0);
+        header.write_to(buffer);
+        Ok(header.request_len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+
+    #[test]
+    fn parse() {
+        let protocol = BinaryProtocol::default();
+
+        // magic=0x80 request, opcode=0x0b version, opaque=0x01020304, rest zero
+        let buffer = [
+            0x80, 0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02,
+            0x03, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        assert_eq!(
+            protocol._parse_request(&buffer),
+            Ok((
+                &b""[..],
+                Request::Version(Version {
+                    opaque: Some(0x01020304)
+                })
+            ))
+        );
+    }
+
+    #[test]
+    fn compose_request() {
+        let protocol = BinaryProtocol::default();
+        let request = Request::Version(Version {
+            opaque: Some(0x01020304),
+        });
+
+        let mut buffer = BytesMut::new();
+        let _ = protocol.compose_request(&request, &mut buffer);
+
+        assert_eq!(
+            &*buffer,
+            &[
+                0x80, 0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02,
+                0x03, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            ]
+        );
+    }
+}

--- a/src/protocol/memcache/src/binary/response/mod.rs
+++ b/src/protocol/memcache/src/binary/response/mod.rs
@@ -3,5 +3,6 @@ use super::*;
 mod delete;
 mod get;
 mod set;
+mod version;
 
 pub(crate) mod header;

--- a/src/protocol/memcache/src/binary/response/version.rs
+++ b/src/protocol/memcache/src/binary/response/version.rs
@@ -1,0 +1,106 @@
+use super::{header::ResponseStatus, *};
+
+impl BinaryProtocol {
+    pub(crate) fn parse_version_response<'a>(
+        &self,
+        _request: &Version,
+        input: &'a [u8],
+        header: ResponseHeader,
+    ) -> IResult<&'a [u8], Response> {
+        match header.status {
+            ResponseStatus::NoError => {
+                if header.key_len != 0 || header.extras_len != 0 {
+                    return Err(nom::Err::Failure(nom::error::Error::new(
+                        input,
+                        nom::error::ErrorKind::Tag,
+                    )));
+                }
+
+                let (input, version) = take(header.total_body_len as usize)(input)?;
+
+                Ok((input, Response::version(String::from_utf8_lossy(version))))
+            }
+            _ => Err(nom::Err::Failure(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Tag,
+            ))),
+        }
+    }
+
+    pub(crate) fn compose_version_response(
+        &self,
+        request: &Version,
+        response: &Response,
+        buffer: &mut dyn BufMut,
+    ) -> std::result::Result<usize, std::io::Error> {
+        match response {
+            Response::Version(version) => {
+                let body = version.inner.as_bytes();
+
+                ResponseHeader {
+                    magic: MagicValue::Response,
+                    opcode: Opcode::Version,
+                    key_len: 0,
+                    extras_len: 0,
+                    data_type: 0x00,
+                    status: ResponseStatus::NoError,
+                    total_body_len: body.len() as u32,
+                    opaque: request.opaque.unwrap_or(0),
+                    cas: 0,
+                }
+                .write_to(buffer);
+
+                buffer.put_slice(body);
+
+                Ok(24 + body.len())
+            }
+            other => Ok(response::ServerError {
+                inner: format!("unknown response: {other}"),
+            }
+            .write_binary_response(Opcode::Version, buffer)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+
+    #[test]
+    fn compose_response() {
+        let protocol = BinaryProtocol::default();
+        let request = Request::Version(Version {
+            opaque: Some(0x00000001),
+        });
+        let response = Response::version("0.3.2");
+
+        let mut buffer = BytesMut::new();
+        let _ = protocol.compose_response(&request, &response, &mut buffer);
+
+        assert_eq!(
+            &*buffer,
+            &[
+                // header
+                0x81, 0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00,
+                0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // body: "0.3.2"
+                0x30, 0x2e, 0x33, 0x2e, 0x32,
+            ]
+        );
+    }
+
+    #[test]
+    fn round_trip() {
+        let protocol = BinaryProtocol::default();
+        let request = Request::Version(Version {
+            opaque: Some(0x00000001),
+        });
+        let response = Response::version("0.3.2");
+
+        let mut buffer = BytesMut::new();
+        let _ = protocol.compose_response(&request, &response, &mut buffer);
+
+        let parsed = protocol.parse_response(&request, &buffer).unwrap();
+        assert_eq!(parsed.into_inner(), Response::version("0.3.2"));
+    }
+}

--- a/src/protocol/memcache/src/metrics.rs
+++ b/src/protocol/memcache/src/metrics.rs
@@ -214,4 +214,11 @@ pub static FLUSH_ALL_EX: Counter = Counter::new();
 #[metric(name = "quit")]
 pub static QUIT: Counter = Counter::new();
 
+/*
+ * VERSION
+ */
+
+#[metric(name = "version")]
+pub static VERSION: Counter = Counter::new();
+
 common::metrics::test_no_duplicates!();

--- a/src/protocol/memcache/src/request/mod.rs
+++ b/src/protocol/memcache/src/request/mod.rs
@@ -21,6 +21,7 @@ mod prepend;
 mod quit;
 mod replace;
 mod set;
+mod version;
 
 pub use add::Add;
 pub use append::Append;
@@ -34,6 +35,7 @@ pub use prepend::Prepend;
 pub use quit::Quit;
 pub use replace::Replace;
 pub use set::Set;
+pub use version::Version;
 
 pub const DEFAULT_MAX_BATCH_SIZE: usize = 1024;
 pub const DEFAULT_MAX_KEY_LEN: usize = 250;
@@ -66,6 +68,7 @@ pub enum Request {
     Quit(Quit),
     Replace(Replace),
     Set(Set),
+    Version(Version),
 }
 
 impl Request {
@@ -182,6 +185,7 @@ impl Display for Request {
             Request::Quit(_) => write!(f, "quit"),
             Request::Replace(_) => write!(f, "replace"),
             Request::Set(_) => write!(f, "set"),
+            Request::Version(_) => write!(f, "version"),
         }
     }
 }
@@ -203,6 +207,7 @@ impl Klog for Request {
             Self::Quit(r) => r.klog(response),
             Self::Replace(r) => r.klog(response),
             Self::Set(r) => r.klog(response),
+            Self::Version(r) => r.klog(response),
         }
     }
 }
@@ -222,6 +227,7 @@ pub enum Command {
     Quit,
     Replace,
     Set,
+    Version,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/src/protocol/memcache/src/request/version.rs
+++ b/src/protocol/memcache/src/request/version.rs
@@ -1,0 +1,18 @@
+// Copyright 2026 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use super::*;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Version {
+    pub(crate) opaque: Option<u32>,
+}
+
+impl Version {}
+
+impl Klog for Version {
+    type Response = Response;
+
+    fn klog(&self, _response: &Self::Response) {}
+}

--- a/src/protocol/memcache/src/response/mod.rs
+++ b/src/protocol/memcache/src/response/mod.rs
@@ -15,6 +15,7 @@ mod numeric;
 mod server_error;
 mod stored;
 mod values;
+mod version;
 
 pub use client_error::ClientError;
 pub use deleted::Deleted;
@@ -26,6 +27,7 @@ pub use numeric::Numeric;
 pub use server_error::ServerError;
 pub use stored::Stored;
 pub use values::{Value, Values};
+pub use version::Version as VersionResponse;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Response {
@@ -39,6 +41,7 @@ pub enum Response {
     Values(Values),
     Numeric(Numeric),
     Deleted(Deleted),
+    Version(VersionResponse),
     Hangup,
 }
 
@@ -55,6 +58,7 @@ impl std::fmt::Display for Response {
             Self::Values(_) => write!(f, "VALUES"),
             Self::Numeric(_) => write!(f, "NUMERIC"),
             Self::Deleted(_) => write!(f, "DELETED"),
+            Self::Version(_) => write!(f, "VERSION"),
             Self::Hangup => write!(f, "HANGUP"),
         }
     }
@@ -114,6 +118,12 @@ impl Response {
     pub fn deleted(noreply: bool) -> Self {
         Self::Deleted(Deleted::new(noreply))
     }
+
+    pub fn version<T: ToString>(version: T) -> Self {
+        Self::Version(VersionResponse {
+            inner: version.to_string(),
+        })
+    }
 }
 
 impl From<Values> for Response {
@@ -135,6 +145,7 @@ impl Compose for Response {
             Self::Values(e) => e.compose(session),
             Self::Numeric(e) => e.compose(session),
             Self::Deleted(e) => e.compose(session),
+            Self::Version(e) => e.compose(session),
             Self::Hangup => 0,
         }
     }
@@ -157,6 +168,7 @@ pub enum ResponseType {
     Empty,
     Numeric(u64),
     Deleted,
+    Version,
 }
 
 pub struct ResponseParser {}
@@ -174,6 +186,7 @@ pub(crate) fn response_type(input: &[u8]) -> IResult<&[u8], ResponseType> {
         b"VALUE" => ResponseType::Values,
         b"END" => ResponseType::Empty,
         b"DELETED" => ResponseType::Deleted,
+        b"VERSION" => ResponseType::Version,
         _ => {
             if let Ok(s) = std::str::from_utf8(response_type_token) {
                 if let Ok(value) = s.parse::<u64>() {
@@ -248,6 +261,10 @@ pub(crate) fn response(input: &[u8]) -> IResult<&[u8], Response> {
         (input, ResponseType::Deleted) => {
             let (input, response) = deleted::parse(input)?;
             Ok((input, Response::Deleted(response)))
+        }
+        (input, ResponseType::Version) => {
+            let (input, response) = version::parse(input)?;
+            Ok((input, Response::Version(response)))
         }
     }
 }

--- a/src/protocol/memcache/src/response/version.rs
+++ b/src/protocol/memcache/src/response/version.rs
@@ -1,0 +1,35 @@
+// Copyright 2026 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use super::*;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Version {
+    pub(crate) inner: String,
+}
+
+impl Compose for Version {
+    fn compose(&self, session: &mut dyn BufMut) -> usize {
+        let header = b"VERSION ";
+        let version = self.inner.as_bytes();
+        session.put_slice(header);
+        session.put_slice(version);
+        session.put_slice(b"\r\n");
+        header.len() + version.len() + 2
+    }
+}
+
+pub(crate) fn parse(input: &[u8]) -> IResult<&[u8], Version> {
+    let (input, _) = space0(input)?;
+    let (input, version) = take_till(|b| b == b' ' || b == b'\r')(input)?;
+    let (input, _) = space0(input)?;
+    let (input, _) = crlf(input)?;
+
+    Ok((
+        input,
+        Version {
+            inner: String::from_utf8_lossy(version).to_string(),
+        },
+    ))
+}

--- a/src/protocol/memcache/src/text/mod.rs
+++ b/src/protocol/memcache/src/text/mod.rs
@@ -69,6 +69,7 @@ impl TextProtocol {
             b"quit" | b"QUIT" => Command::Quit,
             b"replace" | b"REPLACE" => Command::Replace,
             b"set" | b"SET" => Command::Set,
+            b"version" | b"VERSION" => Command::Version,
             _ => {
                 // TODO(bmartin): we can return an unknown command error here
                 return Err(nom::Err::Failure(nom::error::Error::new(
@@ -134,6 +135,10 @@ impl TextProtocol {
                 let (input, request) = self.parse_set_request(input)?;
                 Ok((input, Request::Set(request)))
             }
+            (input, Command::Version) => {
+                let (input, request) = self.parse_version_request(input)?;
+                Ok((input, Request::Version(request)))
+            }
         }
     }
 
@@ -155,6 +160,7 @@ impl TextProtocol {
             Request::Quit(_) => self._compose_quit_request(buffer),
             Request::Replace(r) => self._compose_replace_request(r, buffer),
             Request::Set(r) => self._compose_set_request(r, buffer),
+            Request::Version(_) => self._compose_version_request(buffer),
         };
 
         Ok(len)
@@ -177,6 +183,7 @@ impl TextProtocol {
             Request::Prepend(r) => self.parse_prepend_response(r, buffer),
             Request::Replace(r) => self.parse_replace_response(r, buffer),
             Request::Set(r) => self.parse_set_response(r, buffer),
+            Request::Version(r) => self.parse_version_response(r, buffer),
             _ => todo!(),
         }
     }
@@ -202,6 +209,7 @@ impl TextProtocol {
             // Request::Quit(request) => self.compose_quit_response(request, response, buffer),
             Request::Replace(request) => self.compose_replace_response(request, response, buffer),
             Request::Set(request) => self.compose_set_response(request, response, buffer),
+            Request::Version(request) => self.compose_version_response(request, response, buffer),
             _ => todo!(),
         }
 

--- a/src/protocol/memcache/src/text/request/mod.rs
+++ b/src/protocol/memcache/src/text/request/mod.rs
@@ -17,3 +17,4 @@ mod prepend;
 mod quit;
 mod replace;
 mod set;
+mod version;

--- a/src/protocol/memcache/src/text/request/version.rs
+++ b/src/protocol/memcache/src/text/request/version.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use super::*;
+use protocol_common::BufMut;
+
+impl TextProtocol {
+    // this is to be called after parsing the command, so we do not match the verb
+    pub fn parse_version_request<'a>(&self, input: &'a [u8]) -> IResult<&'a [u8], Version> {
+        let (input, _) = space0(input)?;
+        let (input, _) = crlf(input)?;
+
+        #[cfg(feature = "metrics")]
+        VERSION.increment();
+
+        Ok((input, Version { opaque: None }))
+    }
+
+    pub(crate) fn _compose_version_request(&self, session: &mut dyn BufMut) -> usize {
+        session.put_slice(b"version\r\n");
+        9
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse() {
+        let protocol = TextProtocol::new();
+
+        // version command
+        assert_eq!(
+            protocol._parse_request(b"version\r\n"),
+            Ok((&b""[..], Request::Version(Version { opaque: None })))
+        );
+    }
+}

--- a/src/protocol/memcache/src/text/response/mod.rs
+++ b/src/protocol/memcache/src/text/response/mod.rs
@@ -16,3 +16,4 @@ mod incr;
 mod prepend;
 mod replace;
 mod set;
+mod version;

--- a/src/protocol/memcache/src/text/response/version.rs
+++ b/src/protocol/memcache/src/text/response/version.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use super::*;
+
+impl TextProtocol {
+    pub(crate) fn parse_version_response<'a>(
+        &self,
+        _request: &Version,
+        input: &'a [u8],
+    ) -> IResult<&'a [u8], Response> {
+        crate::response(input)
+    }
+
+    #[allow(unused_variables)]
+    pub(crate) fn compose_version_response(
+        &self,
+        request: &Version,
+        response: &Response,
+        buffer: &mut dyn BufMut,
+    ) -> std::result::Result<usize, std::io::Error> {
+        Ok(response.compose(buffer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    use protocol_common::Protocol;
+
+    #[test]
+    fn compose() {
+        let protocol = TextProtocol::new();
+        let request = Request::Version(Version { opaque: None });
+        let response = Response::version("0.3.2");
+
+        let mut buffer = Vec::new();
+        let _ = protocol.compose_response(&request, &response, &mut buffer);
+
+        assert_eq!(&buffer[..], b"VERSION 0.3.2\r\n");
+    }
+
+    #[test]
+    fn parse() {
+        assert_eq!(
+            crate::response(b"VERSION 0.3.2\r\n"),
+            Ok((&b""[..], Response::version("0.3.2")))
+        );
+    }
+}

--- a/src/server/segcache/tests/common.rs
+++ b/src/server/segcache/tests/common.rs
@@ -194,6 +194,15 @@ pub fn tests() {
         &[("prepend 8 0 0 1\r\n0\r\n", Some("ERROR\r\n"))],
     );
 
+    // version command on the data listener
+    test(
+        "version",
+        &[(
+            "version\r\n",
+            Some(&format!("VERSION {}\r\n", env!("CARGO_PKG_VERSION"))),
+        )],
+    );
+
     std::thread::sleep(Duration::from_millis(500));
 }
 


### PR DESCRIPTION
## Summary
- Add `version` command support to the memcache data listener, matching real memcached, in both the ASCII **text** protocol and the **binary** protocol (opcode `0x0b`). Previously `VERSION` was only handled on the admin listener, so the data port rejected `version` as an unknown command.
- Introduce a shared `Version` request/response in `protocol-memcache`, wired through both encoders/decoders (parse + compose + dispatch), plus a `version` metric.
- The segcache entrystore answers with `env!("CARGO_PKG_VERSION")` — the same value the admin port and `--version` report (e.g. `VERSION 0.3.2\r\n`).

## Test plan
- [x] `cargo test -p protocol-memcache` — 38 unit tests pass (text + binary parse/compose/round-trip)
- [x] `cargo test --workspace` — green, including a new segcache integration case asserting `version\r\n` → `VERSION <pkg>\r\n` on the data port
- [x] `cargo +nightly check` on the (out-of-workspace) `protocol-memcache/fuzz` crate — both fuzz targets handle the new `Request::Version` arm
- [x] `cargo fmt --all --check` clean
- [x] Manual smoke test against a running `pelikan-segcache`: `version\r\n` on port 12321 returns `VERSION 0.3.2\r\n`; unknown commands still hang up as before

## Note
The `audit` CI job fails on a pre-existing, unrelated advisory (RUSTSEC-2026-0204, `crossbeam-epoch 0.9.18`, published after #169) — a transitive dependency needing a bump to `>=0.9.20`. Not caused by this change; best handled in a separate dependency-bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)