### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- Bumps the transitive dependency `crossbeam-epoch` from `0.9.18` to `0.9.20` to resolve **RUSTSEC-2026-0204** (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid). The advisory lists `>=0.9.20` as the fix.
- Lockfile-only change; no source or public-API changes.

## Test plan
- [x] `cargo build --workspace` succeeds
- [x] `cargo audit` — the RUSTSEC-2026-0204 vulnerability no longer appears (exit 0; only the two pre-existing allowed warnings remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)