### PR TITLE
fix: remove spurious blank lines from admin stats output

### DIFF
--- a/src/protocol/admin/src/admin.rs
+++ b/src/protocol/admin/src/admin.rs
@@ -190,12 +190,31 @@ pub fn memcache_stats() -> String {
     }
 
     data.sort();
-    data.join("\r\n") + "END\r\n"
+    data.concat() + "END\r\n"
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[metric(name = "stats_format_test_a")]
+    static STATS_FORMAT_TEST_A: Counter = Counter::new();
+
+    #[metric(name = "stats_format_test_b")]
+    static STATS_FORMAT_TEST_B: Counter = Counter::new();
+
+    #[test]
+    fn stats_output_has_no_blank_lines() {
+        // the two counters registered above guarantee at least two STAT lines
+        let stats = memcache_stats();
+        assert!(stats.contains("STAT stats_format_test_a"));
+        assert!(stats.contains("STAT stats_format_test_b"));
+        assert!(
+            !stats.contains("\r\n\r\n"),
+            "stats output must not contain blank lines"
+        );
+        assert!(stats.ends_with("END\r\n"));
+    }
 
     #[test]
     fn parse_incomplete() {


### PR DESCRIPTION
## Summary
- `memcache_stats()` pushed entries that already end in CRLF, then joined them with a CRLF separator — injecting a blank line between every `STAT` row in admin `stats` output
- Strict memcached-protocol clients may not tolerate blank lines inside a `stats` block
- Found during the README verification pass (#173); fixed via TDD with a regression test that registers two test metrics and asserts the output contains no `\r\n\r\n` and terminates with `END`

## Test plan
- [x] New regression test `stats_output_has_no_blank_lines` (watched fail before the fix, passes after)
- [x] All `protocol-admin` tests pass; `cargo fmt --check` and clippy clean
- [x] Live-verified against a running `pelikan-segcache`: `stats` rows are now contiguous (`STAT add 0\r\n` directly followed by the next row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)