### PR TITLE
ci: eliminate push/PR double-build and other CI speedups

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -2,11 +2,16 @@ name: cargo-build
 
 on:
   push:
+    branches: [ main ]
   pull_request:
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   # First stage: these are quick jobs that give immediate feedback on a PR.
@@ -71,7 +76,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: clippy-sarif
-    - uses: github/codeql-action/upload-sarif@v2
+    - uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: clippy.sarif
 
@@ -79,10 +84,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: check-ubuntu-latest
-          save-if: false
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-audit

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,6 +2,7 @@ name: cargo-fuzz
 
 on:
   push:
+    branches: [ main ]
   pull_request:
 
 env:
@@ -31,7 +32,7 @@ jobs:
         run: |
           export CARGO_TARGET_DIR=$(pwd)/target
 
-          for target in protocol/admin protocol/memcache protocol/ping; do
+          for target in protocol/admin protocol/memcache protocol/ping protocol/resp; do
             cd src/$target
             echo "::group::Building $target"
             cargo fuzz build

--- a/docs/journal/2026-08-09-ci-build-speedups.md
+++ b/docs/journal/2026-08-09-ci-build-speedups.md
@@ -1,0 +1,37 @@
+# CI build speedups
+
+## What
+
+Investigated why every PR push runs CI twice and what else slows the build.
+Measured from actual run history: pushes to same-repo PR branches fire both
+`push` and `pull_request` events (verified: head SHA `a272ed16` produced four
+simultaneous workflow runs), duplicating ~18 jobs / ~70 raw runner-minutes per
+push — more in billed minutes since four of the duplicated jobs run on macOS.
+
+## Decided
+
+- Scope `push` triggers to `main` in both workflows; `pull_request` covers PR
+  branches (fork PRs already only get `pull_request` runs).
+- Add concurrency cancellation to `cargo.yml` (`fuzz.yml` already had it), so
+  rapid successive pushes stop stacking complete 35-minute run-sets.
+- Add `protocol/resp` to the fuzz warm-up build loop: the fuzz jobs restore
+  the shared cache with `save-if: false`, so resp — absent from the loop that
+  populates the cache — was compiled cold on every run, forever.
+- Drop the rust-cache restore from the `audit` job: `cargo audit` only reads
+  `Cargo.lock`; restoring a build cache there was pure overhead.
+- Bump `codeql-action/upload-sarif` v2 → v3 (v2 is past end of support).
+
+## Open
+
+Deliberately not done here, as they change artifacts or have tradeoffs:
+
+- Release profile carries `debug = true` + fat LTO + `codegen-units = 1`,
+  making the release build+test jobs the critical path (8-13 min). Options: a
+  CI-only `[profile.ci-release]` with thin LTO, or `debug = "line-tables-only"`
+  in release. Changes shipped artifacts — maintainer decision.
+- rust-cache saves from every branch may evict main's caches under the 10GB
+  cap; `save-if: github.ref == 'refs/heads/main'` on big jobs is an option.
+- `clippy` runs with `continue-on-error: true`, so clippy failures never gate
+  `check-success` — only SARIF annotations. Verify that's intentional.
+- The `check-{os}` jobs are subsumed by `build-{os}-debug`; their only value
+  is ~1-minute fast feedback. The macOS leg is 10x-billed.


### PR DESCRIPTION
## Summary
- **Double-build confirmed and eliminated**: pushes to same-repo PR branches fired both `push` and `pull_request` events, running all ~18 jobs twice (~70 raw runner-minutes per push, more billed since 4 duplicated jobs are on macOS). Verified from run history: head SHA `a272ed16` produced four simultaneous workflow runs. `push` is now scoped to `main`; `pull_request` covers PR branches, and fork PRs are unaffected (they already only got `pull_request` runs).
- **Concurrency cancellation for cargo.yml**: rapid successive pushes previously stacked complete ~35-minute run-sets; `fuzz.yml` already had this block, `cargo.yml` now matches. Main-branch runs never cancel each other (group falls back to `run_id`).
- **Fuzz cache gap**: the warm-up `build` job cached `protocol/{admin,memcache,ping}` but not `protocol/resp`, while fuzz jobs restore with `save-if: false` — so the resp fuzz target compiled cold on every run, forever. Added to the loop.
- **Audit job**: dropped the rust-cache restore — `cargo audit` only reads `Cargo.lock`, the build-cache restore was pure overhead.
- **codeql-action/upload-sarif v2 → v3**: v2 is past end of support and will eventually hard-fail.

## Deliberately not included (tradeoffs for maintainer judgment, detailed in docs/journal/2026-08-09-ci-build-speedups.md)
- Release profile (`debug = true`, fat LTO, `codegen-units = 1`) makes release build+test the 8–13 min critical path; a CI-only profile or `debug = "line-tables-only"` would cut it but changes shipped artifacts
- `save-if: main` on big caches to stop PR branches evicting main's caches
- `clippy` runs `continue-on-error: true`, so clippy failures never gate `check-success` — flagging in case that's unintentional
- `check-{os}` matrix is subsumed by `build-{os}-debug`; macOS leg is 10x-billed

## Test plan
- [x] Both workflow files parse as valid YAML
- [x] Trigger semantics: `push: branches: [main]` + bare `pull_request` is the standard non-duplicating pattern; this PR itself will demonstrate it (expect exactly one run-set per workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)