### PR TITLE
chore: fix contributor papercuts from README verification pass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Pelikan
+
+Thanks for your interest in contributing! This guide covers the practical
+steps; for questions and discussions, join our
+[Discord server](https://discord.gg/yUBWHqxGUR).
+
+## Prerequisites
+
+- Rust [stable toolchain](https://www.rust-lang.org/learn/get-started)
+- C toolchain and `cmake` (used to build AWS-LC, the cryptography library
+  backing our TLS support)
+
+## Building and testing
+
+```sh
+cargo build --workspace           # debug build
+cargo build --workspace --release # release build
+cargo test --workspace            # run all tests
+```
+
+Note: integration tests bind the default ports (`12321` data, `9999` admin);
+stop any running pelikan server instance before running the test suite.
+
+Before submitting, make sure the following pass — CI enforces them:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features
+cargo test --workspace
+```
+
+## Submitting a change
+
+1. Create a new issue describing the problem or feature
+2. Fork on GitHub and clone your fork
+3. Create a feature branch on your fork
+4. Make your change; keep commits focused and use
+   [conventional commit](https://www.conventionalcommits.org/) style
+   (`feat:`, `fix:`, `docs:`, `chore:`, ...) matching the existing history
+5. Push your feature branch
+6. Create a pull request linked to the issue
+
+## Project layout
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for how the workspace is
+organized. Non-trivial efforts are logged in [docs/journal/](docs/journal/).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[Apache 2.0 license](LICENSE).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pelikan-pingproxy"
+version = "0.3.2"
+dependencies = [
+ "backtrace",
+ "clap",
+ "common",
+ "config",
+ "logger",
+ "metriken",
+ "protocol-ping",
+ "proxy",
+]
+
+[[package]]
 name = "pelikan-pingserver"
 version = "0.3.2"
 dependencies = [
@@ -1227,20 +1241,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pingproxy"
-version = "0.3.2"
-dependencies = [
- "backtrace",
- "clap",
- "common",
- "config",
- "logger",
- "metriken",
- "protocol-ping",
- "proxy",
-]
 
 [[package]]
 name = "plotters"

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ included under the `config` directory.
 
 ## Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites, build and test
+commands, and the checks CI enforces.
+
 If you want to submit a patch, please follow these steps:
 
 1. create a new issue

--- a/src/proxy/ping/Cargo.toml
+++ b/src/proxy/ping/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pingproxy"
+name = "pelikan-pingproxy"
 authors = ["Brian Martin <brian@pelikan.io>"]
 
 version = { workspace = true }


### PR DESCRIPTION
## Summary
- Rename the `pingproxy` package to `pelikan-pingproxy`, matching its `[[bin]]` name and the `pelikan-<name>` convention every other product package follows — `cargo build -p pelikan-pingproxy` previously failed with "package ID specification did not match any packages" (found during the README verification pass, #173). The binary name, lib name, and CI artifact step are unchanged.
- Add `CONTRIBUTING.md`: prerequisites, build/test commands, the integration-test port-conflict gotcha, CI-enforced checks (fmt/clippy/test), the fork-and-PR flow the README describes, and pointers to `docs/ARCHITECTURE.md` and the journal.

## Test plan
- [x] `cargo build -p pelikan-pingproxy` fails before, succeeds after the rename
- [x] `cargo build --workspace` clean; `cargo fmt --check` clean; no other crate references the old package name
- [x] All paths referenced by CONTRIBUTING.md resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)