### PR TITLE
fix: graceful shutdown on SIGTERM/SIGINT/SIGQUIT for proxy binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,7 @@ dependencies = [
  "config",
  "crossbeam-channel",
  "entrystore",
+ "libc",
  "logger",
  "metriken",
  "pelikan-net",
@@ -1436,6 +1437,7 @@ dependencies = [
  "protocol-common",
  "queues",
  "session",
+ "signal-hook",
  "slab",
 ]
 

--- a/docs/diagrams/threading.svg
+++ b/docs/diagrams/threading.svg
@@ -179,11 +179,15 @@
 <text x="1643" y="896" dy="0.35em" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="normal" fill="#000" font-style="italic" text-anchor="middle">servers</text>
 <path d="M 1518 896 L 1598 896" fill="none" stroke="#4D4D4D" stroke-width="2.4" marker-end="url(#a)" marker-start="url(#a)"/>
 <text x="1558" y="886" dy="0.35em" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="normal" fill="#555" text-anchor="middle">connect</text>
+<rect x="50" y="1108" width="270" height="92" fill="#FFFFFF" stroke="#4D4D4D" stroke-width="1.5" rx="10"/>
+<text x="185" y="1128" dy="0.35em" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="17" font-weight="bold" fill="#000" text-anchor="middle">pelikan_signal</text>
+<text x="185" y="1154" dy="0.35em" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="normal" fill="#333" font-style="italic" text-anchor="middle">SIGINT/TERM/QUIT</text>
 <rect x="354" y="1108" width="270" height="92" fill="#FFFFFF" stroke="#4D4D4D" stroke-width="1.5" rx="10"/>
 <text x="489" y="1128" dy="0.35em" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="17" font-weight="bold" fill="#000" text-anchor="middle">pelikan_admin</text>
 <text x="489" y="1154" dy="0.35em" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="normal" fill="#333" text-anchor="middle">:9999</text>
 <rect x="362" y="1168" width="254" height="24" fill="#FBB4AE" stroke="#4D4D4D" stroke-width="1" rx="0"/>
 <text x="489" y="1180" dy="0.35em" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="normal" fill="#000" text-anchor="middle">protocol-admin</text>
+<path d="M 320 1154 L 354 1154" fill="none" stroke="#999999" stroke-width="1.4" stroke-dasharray="5,4" marker-end="url(#a)"/>
 <path d="M 394 1108 L 394 942" fill="none" stroke="#999999" stroke-width="1.4" stroke-dasharray="5,4" marker-end="url(#a)"/>
 <text x="368" y="1025" dy="0.35em" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="normal" fill="#777" text-anchor="middle">signals</text>
 <path d="M 624 1154 L 927 1154 L 927 1068" fill="none" stroke="#999999" stroke-width="1.4" stroke-dasharray="5,4" marker-end="url(#a)"/>

--- a/docs/journal/2026-08-09-architecture-diagrams.md
+++ b/docs/journal/2026-08-09-architecture-diagrams.md
@@ -175,7 +175,10 @@ runtime half:
 - **Negative claims matter**: the proxy core spawns no signal-handler
   thread — asserted as an absence check, and visible as the missing box.
   Possible real gap: pingproxy ignores SIGTERM (no graceful shutdown path
-  from OS signals).
+  from OS signals). *Update 2026-08-12: confirmed real and fixed — the
+  proxy core now spawns `pelikan_signal` mirroring the server core; the
+  fix tripped the absence claim exactly as designed, and the claim
+  flipped to a positive one.*
 - **Source anchoring for runtime charts**: 17 grep assertions (thread
   spawns, queue wiring, signal set, ports, upstream connect) abort
   generation on drift — the runtime analog of deriving from cargo

--- a/src/core/proxy/Cargo.toml
+++ b/src/core/proxy/Cargo.toml
@@ -15,11 +15,13 @@ clocksource = { workspace = true }
 config = { path = "../../config" }
 crossbeam-channel = { workspace = true }
 entrystore = { path = "../../entrystore" }
+libc = { workspace = true }
 logger = { path = "../../logger" }
 metriken = { workspace = true }
 pelikan-net = { workspace = true, features = ["metrics"] }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 session = { path = "../../session" }
+signal-hook = { workspace = true }
 slab = { workspace = true }
 queues = { workspace = true }

--- a/src/core/proxy/src/process.rs
+++ b/src/core/proxy/src/process.rs
@@ -6,7 +6,10 @@ use crate::*;
 use config::proxy::BackendConfig;
 use config::proxy::FrontendConfig;
 use config::proxy::ListenerConfig;
+use libc::c_int;
 use protocol_common::Protocol;
+use signal_hook::consts::signal::*;
+use signal_hook::iterator::Signals;
 use std::thread::JoinHandle;
 
 pub struct ProcessBuilder<
@@ -157,6 +160,16 @@ where
             })
             .collect();
 
+        let cloned_signal_tx = signal_tx.clone();
+
+        // NOTE: Signal handler join handle is not taken ownership of by [Process] as it's
+        // considered something that has the same lifetime as the actual OS process as a whole
+        // and there aren't any current use cases for blocking on join()'ing the thread
+        // if we want to dynamically rebind signal handlers in the future we should reconsider this
+        let _signal_handler = std::thread::Builder::new()
+            .name(format!("{THREAD_PREFIX}_signal"))
+            .spawn(move || Process::signal_handler(&cloned_signal_tx));
+
         Process {
             admin,
             backend,
@@ -186,12 +199,35 @@ impl Process {
     pub fn shutdown(self) {
         // this sends a shutdown to the admin thread, which will broadcast the
         // signal to all sibling threads in the process
-        if self.signal_tx.try_send(Signal::Shutdown).is_err() {
-            fatal!("error sending shutdown signal to thread");
-        }
+        Process::shutdown_signal(&self.signal_tx);
 
         // wait and join all threads
         self.wait()
+    }
+
+    /// Communicates to the admin thread that shutdown should occur
+    fn shutdown_signal(signal_tx: &Sender<Signal>) {
+        if signal_tx.try_send(Signal::Shutdown).is_err() {
+            fatal!("error sending shutdown signal to thread");
+        }
+    }
+
+    /// Registers Process to listen to relevant signals
+    /// and depending on the signal, may relay Pelikan [Signal] messages to admin channel
+    fn signal_handler(signal_tx: &Sender<Signal>) {
+        const SIGNALS: &[c_int] = &[SIGHUP, SIGINT, SIGTERM, SIGQUIT];
+        let mut signals = Signals::new(SIGNALS).expect("Couldn't instantiate Signals");
+
+        //Infinite iterator of signals
+        for signal in &mut signals {
+            match signal {
+                SIGTERM | SIGINT | SIGQUIT => {
+                    Process::shutdown_signal(signal_tx);
+                    break;
+                }
+                _ => (),
+            }
+        }
     }
 
     /// Will block until all threads terminate. This should be used to keep the

--- a/xtask/src/threading.rs
+++ b/xtask/src/threading.rs
@@ -70,6 +70,16 @@ const CLAIMS: &[Claim] = &[
     },
     Claim {
         path: "src/core/proxy/src/process.rs",
+        pattern: r#"name\(format!\("\{THREAD_PREFIX\}_signal"\)\)"#,
+        what: "proxy signal handler thread spawn",
+    },
+    Claim {
+        path: "src/core/proxy/src/process.rs",
+        pattern: r"SIGHUP, SIGINT, SIGTERM, SIGQUIT",
+        what: "proxy signal handler signal set",
+    },
+    Claim {
+        path: "src/core/proxy/src/process.rs",
         pattern: r#"name\(format!\("\{THREAD_PREFIX\}_fe_\{i\}"\)\)"#,
         what: "proxy frontend worker spawn",
     },
@@ -101,11 +111,7 @@ const CLAIMS: &[Claim] = &[
 ];
 
 /// Claims of absence: the diagram relies on these NOT existing.
-const NEG_CLAIMS: &[Claim] = &[Claim {
-    path: "src/core/proxy/src/process.rs",
-    pattern: r"\{THREAD_PREFIX\}_signal",
-    what: "proxy core has no OS signal-handler thread",
-}];
+const NEG_CLAIMS: &[Claim] = &[];
 
 type Chip = (&'static str, &'static str);
 const CHIP_PROTOCOL: Chip = ("protocol-*", FILL_PROTOCOL);
@@ -647,9 +653,18 @@ fn proxy_panel(y0: f64, title: &str, rows: &[(&str, &str)]) -> (Vec<String>, f64
             .build(),
     );
 
-    // control plane: admin only — the proxy core installs no OS signal
-    // handler (see NEG_CLAIMS)
+    // control plane: signal left of admin, admin aligned under listener
     let row_b = y0 + h - 100.0;
+    let sg_x = X0 + 26.0;
+    thread_box(
+        &mut parts,
+        sg_x,
+        row_b,
+        "pelikan_signal",
+        Some("SIGINT/TERM/QUIT"),
+        &[],
+        true,
+    );
     thread_box(
         &mut parts,
         li_x,
@@ -660,6 +675,11 @@ fn proxy_panel(y0: f64, title: &str, rows: &[(&str, &str)]) -> (Vec<String>, f64
         false,
     );
     let mid_b = row_b + TB_H / 2.0;
+    parts.push(
+        ortho(&[(sg_x + TB_W, mid_b), (li_x, mid_b)])
+            .signal()
+            .build(),
+    );
     parts.push(
         ortho(&[(li_x + 40.0, row_b), (li_x + 40.0, row_a + TB_H)])
             .signal()


### PR DESCRIPTION
## Summary
- The proxy core had the complete internal shutdown machinery — admin broadcasts `Signal::Shutdown` to every sibling thread, `Process::shutdown()` drains and joins — but never installed an OS signal handler to trigger it, so `pelikan-pingproxy` died abruptly on SIGTERM with no graceful drain, unlike the servers. This spawns a `pelikan_signal` thread in the proxy core mirroring the server core's handler (same signal set: SIGHUP watched; SIGTERM/SIGINT/SIGQUIT relay shutdown), feeding the existing path. `shutdown()` is refactored to share the same `shutdown_signal` helper as the server for parity.
- The gap was originally surfaced by the threading diagram's **negative claim** ("proxy core spawns no signal-handler thread"), and the fix tripped that claim exactly as designed — `cargo xtask diagrams` refused to regenerate until the chart was updated. The claim flips to two positive ones (spawn site + signal set), and the regenerated proxy panel gains the `pelikan_signal` box, making all three panels' control planes identical.

## Test plan
- [x] Live test: started pingserver + pingproxy, confirmed `pelikan_signal` thread in `ps -T`, PING round-trips through the proxy, then SIGTERM → `admin: shutting down` logged, exit code 0 (previously: abrupt termination)
- [x] `cargo xtask diagrams` passes all claims; regenerated `threading.svg` reviewed rendered
- [x] `cargo build -p proxy`, `cargo test -p proxy`, fmt, clippy clean (remaining clippy warnings are pre-existing in pelikan-net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)