### PR TITLE
ci: harden fuzz workflow against install flakes (fail-fast off, cached cargo-fuzz)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -28,7 +28,11 @@ jobs:
         with:
           shared-key: fuzz
           prefix-key: v1-rust
-      - uses: dtolnay/install@cargo-fuzz
+      # cargo-install builds once and caches the binary, immune to the
+      # release-CDN 503s that dtolnay/install (prebuilt download) hit
+      - uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-fuzz
 
       - name: cargo build
         shell: bash
@@ -86,7 +90,11 @@ jobs:
           shared-key: fuzz
           prefix-key: v1-rust
           save-if: false
-      - uses: dtolnay/install@cargo-fuzz
+      # cargo-install builds once and caches the binary, immune to the
+      # release-CDN 503s that dtolnay/install (prebuilt download) hit
+      - uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-fuzz
 
       # Persist the libFuzzer corpus across runs so each run starts from
       # accumulated coverage instead of rediscovering it from scratch. The

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -65,6 +65,9 @@ jobs:
 
   fuzz:
     strategy:
+      # one target's failure (a real crash or a transient runner error) must
+      # not cancel the other targets' coverage
+      fail-fast: false
       matrix:
         include:
           - { os: ubuntu-latest, dir: protocol/admin, target: admin }


### PR DESCRIPTION
## Summary
Two hardenings against the failure mode that hit today's fuzz runs (repeated HTTP 503s from GitHub's release CDN while installing cargo-fuzz — twice within an hour, on different targets; not a fuzzer finding):

- **`fail-fast: false`** on the fuzz matrix: one target's failure — transient or a real crash — no longer cancels the other targets' coverage. The per-target matrix from #179 made targets independent by design; this completes it. `verify all fuzz tests pass` still gates on all five.
- **cargo-fuzz installed via `baptiste0928/cargo-install`** (already used for cargo-audit) instead of `dtolnay/install`'s prebuilt download: builds once, cached thereafter, immune to release-CDN outages. Costs ~1–2 min on the first uncached run, seconds after.

## Test plan
- [x] YAML parses
- [ ] CI on this PR: five fuzz jobs, none cancelled by siblings, cargo-fuzz installed from cache/build rather than CDN download

🤖 Generated with [Claude Code](https://claude.com/claude-code)
