### PR TITLE
docs: journal skill records skill use and beta-skill feedback

### DIFF
--- a/.agent/skills/journal/SKILL.md
+++ b/.agent/skills/journal/SKILL.md
@@ -24,3 +24,45 @@ Create or continue an entry in `docs/journal/` — pelikan's in-repo, contributo
 
 - A pre-commit hook (`.agent/hooks/pre-commit-check.sh`) nudges — non-blocking — when a commit touches `src/` without a corresponding `docs/journal/*.md` entry staged.
 - This is separate from, not a replacement for, the MCP `engineering-journal` / knowledge-iop vault skills — those stay optional, for maintainers who want to mirror significant entries cross-project.
+
+## Record skill use
+
+Every entry ends with a roster of the skills invoked during the effort:
+
+```markdown
+## Appendix: Skills Invoked
+
+- `architecture-diagram` (beta) — legibility passes over the chart set.
+```
+
+The roster covers the whole effort, not the current session: append on
+update, never rewrite it down to what one session remembers, and when the
+record is incomplete (compaction, handoff, resumed effort) say so in one
+line instead of inferring a plausible list. List only skills actually
+invoked; omit the appendix when none were.
+
+A skill is beta when its own text or template manifest says so, or when
+the user says so — never inferred from one bad result. Mark beta skills
+`(beta)` in the roster, name them in `beta_skills:` frontmatter, and give
+each a subsection:
+
+```markdown
+---
+beta_skills: [architecture-diagram]
+---
+
+## Skill Feedback
+
+### architecture-diagram (beta)
+
+- **Friction** — what was asked, which instruction misfired, what was
+  done instead.
+- **Confirmation** — a default that held under real use.
+```
+
+Record friction and confirmation both — a beta skill needs evidence its
+defaults survive contact, not a complaint log. Drop any friction that
+cannot concretely name the ask, the misfiring instruction, and the
+deviation. The record is advisory: do not edit the skill, open an issue,
+or send anything upstream unless the user separately asks. Never backfill
+a roster or feedback section into entries that predate this convention.


### PR DESCRIPTION
## Summary
- Upgrades pelikan's `journal` skill to the skill-use convention just landed in the upstream engineering-journal skill (iopsystems/skills-mcp#23): every entry closes with an `## Appendix: Skills Invoked` roster, and any beta skill invoked gets a `## Skill Feedback` subsection (friction **and** confirmation), keyed by `beta_skills:` frontmatter so a future survey can find candidates without parsing prose.
- The honesty rules carry over: append-only roster, incompleteness stated rather than inferred, no backfill into pre-convention entries, and every friction must name the ask, the misfiring instruction, and the deviation.
- Kept in pelikan's thin-skill register rather than seeding the full `engineering-journal-skill` template — consistent with the repo's load-bearing-plus-index philosophy. First application (feedback on `architecture-diagram` (beta) from the #183 work) lands on that PR's branch, where the entry lives.

## Test plan
- [x] Skill re-registers with the appended section
- [x] Convention matches the upstream contract's obligations point for point

🤖 Generated with [Claude Code](https://claude.com/claude-code)