### PR TITLE
refactor: consolidate product main.rs into pelikan_main! macro

### DIFF
--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod bytes;
 pub mod expiry;
 pub mod metrics;
+pub mod product;
 pub mod signal;
 pub mod ssl;
 pub mod traits;

--- a/src/common/src/product.rs
+++ b/src/common/src/product.rs
@@ -7,16 +7,61 @@
 /// `common` itself needs no clap/metriken/logger edges. Callers must have
 /// `#[macro_use] extern crate logger` in scope for the `debug!` line.
 ///
-/// `print_config: true` requires the config type to implement `print()`;
-/// omit the field for configs that cannot print themselves.
+/// `print_config` is a presence-only marker, not a toggle: include it to
+/// add the `-c`/`--config` flag (the config type must implement
+/// `print()`), omit it for configs that cannot print themselves.
+/// `print_config: false` does not exist and will not compile.
+///
+/// The `@main` arm is internal. The public arms pass the `matches` and
+/// `config` binding idents alongside the code fragments that reference
+/// them, so both sides share one hygiene context.
 #[macro_export]
 macro_rules! pelikan_main {
     (
         about: $about:expr,
         config: $config:ty,
         percentiles: $percentiles:expr,
-        $(print_config: $print_config:literal,)?
+        print_config,
         launch: $launch:expr $(,)?
+    ) => {
+        $crate::pelikan_main! {
+            @main $about, $config, $percentiles, $launch,
+            idents: [matches, config],
+            args: {
+                .arg(
+                    ::clap::Arg::new("print-config")
+                        .short('c')
+                        .long("config")
+                        .help("List all options in config")
+                        .action(::clap::ArgAction::SetTrue),
+                )
+            },
+            post_load: {
+                if matches.get_flag("print-config") {
+                    config.print();
+                    ::std::process::exit(0);
+                }
+            }
+        }
+    };
+    (
+        about: $about:expr,
+        config: $config:ty,
+        percentiles: $percentiles:expr,
+        launch: $launch:expr $(,)?
+    ) => {
+        $crate::pelikan_main! {
+            @main $about, $config, $percentiles, $launch,
+            idents: [matches, config],
+            args: {},
+            post_load: {}
+        }
+    };
+    (
+        @main $about:expr, $config:ty, $percentiles:expr, $launch:expr,
+        idents: [$matches:ident, $cfg:ident],
+        args: { $($args:tt)* },
+        post_load: { $($post_load:tt)* }
     ) => {
         fn main() {
             // custom panic hook to terminate whole process after unwinding
@@ -27,7 +72,7 @@ macro_rules! pelikan_main {
             }));
 
             // parse command line options
-            let mut command = ::clap::Command::new(env!("CARGO_BIN_NAME"))
+            let $matches = ::clap::Command::new(env!("CARGO_BIN_NAME"))
                 .version(env!("CARGO_PKG_VERSION"))
                 .long_about($about)
                 .arg(
@@ -42,21 +87,12 @@ macro_rules! pelikan_main {
                         .help("Server configuration file")
                         .action(::clap::ArgAction::Set)
                         .index(1),
-                );
-            $(
-                let _: bool = $print_config;
-                command = command.arg(
-                    ::clap::Arg::new("print-config")
-                        .short('c')
-                        .long("config")
-                        .help("List all options in config")
-                        .action(::clap::ArgAction::SetTrue),
-                );
-            )?
-            let matches = command.get_matches();
+                )
+                $($args)*
+                .get_matches();
 
             // output stats descriptions and exit if the `stats` option was provided
-            if matches.get_flag("stats") {
+            if $matches.get_flag("stats") {
                 println!("{:<31} {:<15} DESCRIPTION", "NAME", "TYPE");
 
                 let mut metrics = ::std::vec::Vec::new();
@@ -93,7 +129,7 @@ macro_rules! pelikan_main {
             }
 
             // load config from file
-            let config: $config = if let Some(file) = matches.get_one::<String>("CONFIG") {
+            let $cfg: $config = if let Some(file) = $matches.get_one::<String>("CONFIG") {
                 debug!("loading config: {file}");
                 match <$config>::load(file) {
                     Ok(c) => c,
@@ -106,15 +142,9 @@ macro_rules! pelikan_main {
                 Default::default()
             };
 
-            $(
-                let _: bool = $print_config;
-                if matches.get_flag("print-config") {
-                    config.print();
-                    ::std::process::exit(0);
-                }
-            )?
+            $($post_load)*
 
-            ($launch)(config)
+            ($launch)($cfg)
         }
     };
 }

--- a/src/common/src/product.rs
+++ b/src/common/src/product.rs
@@ -1,0 +1,120 @@
+/// Expands to the standard product `main()`: panic hook, CLI parsing,
+/// `--stats` metric listing, config load, optional `--config` printing,
+/// then launch.
+///
+/// A macro rather than a generic fn so every binary stays monomorphic and
+/// the expanded tokens resolve against the product's own dependency set;
+/// `common` itself needs no clap/metriken/logger edges. Callers must have
+/// `#[macro_use] extern crate logger` in scope for the `debug!` line.
+///
+/// `print_config: true` requires the config type to implement `print()`;
+/// omit the field for configs that cannot print themselves.
+#[macro_export]
+macro_rules! pelikan_main {
+    (
+        about: $about:expr,
+        config: $config:ty,
+        percentiles: $percentiles:expr,
+        $(print_config: $print_config:literal,)?
+        launch: $launch:expr $(,)?
+    ) => {
+        fn main() {
+            // custom panic hook to terminate whole process after unwinding
+            ::std::panic::set_hook(::std::boxed::Box::new(|s| {
+                eprintln!("{s}");
+                eprintln!("{:?}", ::backtrace::Backtrace::new());
+                ::std::process::exit(101);
+            }));
+
+            // parse command line options
+            let mut command = ::clap::Command::new(env!("CARGO_BIN_NAME"))
+                .version(env!("CARGO_PKG_VERSION"))
+                .long_about($about)
+                .arg(
+                    ::clap::Arg::new("stats")
+                        .short('s')
+                        .long("stats")
+                        .help("List all metrics in stats")
+                        .action(::clap::ArgAction::SetTrue),
+                )
+                .arg(
+                    ::clap::Arg::new("CONFIG")
+                        .help("Server configuration file")
+                        .action(::clap::ArgAction::Set)
+                        .index(1),
+                );
+            $(
+                let _: bool = $print_config;
+                command = command.arg(
+                    ::clap::Arg::new("print-config")
+                        .short('c')
+                        .long("config")
+                        .help("List all options in config")
+                        .action(::clap::ArgAction::SetTrue),
+                );
+            )?
+            let matches = command.get_matches();
+
+            // output stats descriptions and exit if the `stats` option was provided
+            if matches.get_flag("stats") {
+                println!("{:<31} {:<15} DESCRIPTION", "NAME", "TYPE");
+
+                let mut metrics = ::std::vec::Vec::new();
+
+                for metric in &::metriken::metrics() {
+                    let any = match metric.as_any() {
+                        Some(any) => any,
+                        None => {
+                            continue;
+                        }
+                    };
+
+                    if any.downcast_ref::<::metriken::Counter>().is_some() {
+                        metrics.push(format!("{:<31} counter", metric.name()));
+                    } else if any.downcast_ref::<::metriken::Gauge>().is_some() {
+                        metrics.push(format!("{:<31} gauge", metric.name()));
+                    } else if any.downcast_ref::<::metriken::AtomicHistogram>().is_some()
+                        || any.downcast_ref::<::metriken::RwLockHistogram>().is_some()
+                    {
+                        for (label, _) in $percentiles {
+                            let name = format!("{}_{}", metric.name(), label);
+                            metrics.push(format!("{name:<31} percentile"));
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+
+                metrics.sort();
+                for metric in metrics {
+                    println!("{metric}");
+                }
+                ::std::process::exit(0);
+            }
+
+            // load config from file
+            let config: $config = if let Some(file) = matches.get_one::<String>("CONFIG") {
+                debug!("loading config: {file}");
+                match <$config>::load(file) {
+                    Ok(c) => c,
+                    Err(error) => {
+                        eprintln!("error loading config file: {file}\n{error}");
+                        ::std::process::exit(1);
+                    }
+                }
+            } else {
+                Default::default()
+            };
+
+            $(
+                let _: bool = $print_config;
+                if matches.get_flag("print-config") {
+                    config.print();
+                    ::std::process::exit(0);
+                }
+            )?
+
+            ($launch)(config)
+        }
+    };
+}

--- a/src/proxy/ping/src/main.rs
+++ b/src/proxy/ping/src/main.rs
@@ -5,95 +5,15 @@
 #[macro_use]
 extern crate logger;
 
-use backtrace::Backtrace;
-use clap::{Arg, Command};
 use config::PingproxyConfig;
-use metriken::*;
 use pelikan_pingproxy::Pingproxy;
-
 use proxy::PERCENTILES;
 
-fn main() {
-    // custom panic hook to terminate whole process after unwinding
-    std::panic::set_hook(Box::new(|s| {
-        error!("{s}");
-        println!("{:?}", Backtrace::new());
-        std::process::exit(101);
-    }));
-
-    // parse command line options
-    let matches = Command::new(env!("CARGO_BIN_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .long_about(
-            "A Pelikan proxy server which speaks the ASCII `ping` protocol. It \
-            accepts connections on the listening port, routing requests to the \
-            backend servers and responses back to clients.",
-        )
-        .arg(
-            Arg::new("stats")
-                .short('s')
-                .long("stats")
-                .help("List all metrics in stats")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("CONFIG")
-                .help("Server configuration file")
-                .action(clap::ArgAction::Set)
-                .index(1),
-        )
-        .get_matches();
-
-    // output stats descriptions and exit if the `stats` option was provided
-    if matches.get_flag("stats") {
-        println!("{:<31} {:<15} DESCRIPTION", "NAME", "TYPE");
-
-        let mut metrics = Vec::new();
-
-        for metric in &metriken::metrics() {
-            let any = match metric.as_any() {
-                Some(any) => any,
-                None => {
-                    continue;
-                }
-            };
-
-            if any.downcast_ref::<Counter>().is_some() {
-                metrics.push(format!("{:<31} counter", metric.name()));
-            } else if any.downcast_ref::<Gauge>().is_some() {
-                metrics.push(format!("{:<31} gauge", metric.name()));
-            } else if any.downcast_ref::<AtomicHistogram>().is_some()
-                || any.downcast_ref::<RwLockHistogram>().is_some()
-            {
-                for (label, _) in PERCENTILES {
-                    let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{name:<31} percentile"));
-                }
-            } else {
-                continue;
-            }
-        }
-
-        metrics.sort();
-        for metric in metrics {
-            println!("{metric}");
-        }
-        std::process::exit(0);
-    }
-
-    // load config from file
-    let config = if let Some(file) = matches.get_one::<String>("CONFIG") {
-        match PingproxyConfig::load(file) {
-            Ok(c) => c,
-            Err(e) => {
-                println!("{e}");
-                std::process::exit(1);
-            }
-        }
-    } else {
-        Default::default()
-    };
-
-    // launch proxy
-    Pingproxy::new(config).wait()
+common::pelikan_main! {
+    about: "A Pelikan proxy server which speaks the ASCII `ping` protocol. It \
+        accepts connections on the listening port, routing requests to the \
+        backend servers and responses back to clients.",
+    config: PingproxyConfig,
+    percentiles: PERCENTILES,
+    launch: |config| Pingproxy::new(config).wait(),
 }

--- a/src/server/pingserver/src/main.rs
+++ b/src/server/pingserver/src/main.rs
@@ -1,116 +1,28 @@
 #[macro_use]
 extern crate logger;
 
-use backtrace::Backtrace;
-use clap::{Arg, Command};
 use config::PingserverConfig;
 use entrystore::Noop;
 use logger::configure_logging;
-use metriken::*;
 use protocol_ping::{PingProtocol, Request, Response};
 use server::{ProcessBuilder, PERCENTILES};
 
-fn main() {
-    // custom panic hook to terminate whole process after unwinding
-    std::panic::set_hook(Box::new(|s| {
-        eprintln!("{s}");
-        eprintln!("{:?}", Backtrace::new());
-        std::process::exit(101);
-    }));
-
-    // parse command line options
-    let matches = Command::new(env!("CARGO_BIN_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .long_about(
-            "A minimal ping/pong server built with Pelikan libraries. \
-            Useful for testing and benchmarking the framework with \
-            near-zero application overhead.",
+common::pelikan_main! {
+    about: "A minimal ping/pong server built with Pelikan libraries. \
+        Useful for testing and benchmarking the framework with \
+        near-zero application overhead.",
+    config: PingserverConfig,
+    percentiles: PERCENTILES,
+    launch: |config: PingserverConfig| {
+        let log = configure_logging(&config);
+        common::metrics::init();
+        let storage = Noop::new();
+        let protocol = PingProtocol::default();
+        ProcessBuilder::<PingProtocol, Request, Response, Noop>::new(
+            &config, log, protocol, storage,
         )
-        .arg(
-            Arg::new("stats")
-                .short('s')
-                .long("stats")
-                .help("List all metrics in stats")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("CONFIG")
-                .help("Server configuration file")
-                .action(clap::ArgAction::Set)
-                .index(1),
-        )
-        .get_matches();
-
-    // output stats descriptions and exit if the `stats` option was provided
-    if matches.get_flag("stats") {
-        println!("{:<31} {:<15} DESCRIPTION", "NAME", "TYPE");
-
-        let mut metrics = Vec::new();
-
-        for metric in &metriken::metrics() {
-            let any = match metric.as_any() {
-                Some(any) => any,
-                None => {
-                    continue;
-                }
-            };
-
-            if any.downcast_ref::<Counter>().is_some() {
-                metrics.push(format!("{:<31} counter", metric.name()));
-            } else if any.downcast_ref::<Gauge>().is_some() {
-                metrics.push(format!("{:<31} gauge", metric.name()));
-            } else if any.downcast_ref::<AtomicHistogram>().is_some()
-                || any.downcast_ref::<RwLockHistogram>().is_some()
-            {
-                for (label, _) in PERCENTILES {
-                    let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{name:<31} percentile"));
-                }
-            } else {
-                continue;
-            }
-        }
-
-        metrics.sort();
-        for metric in metrics {
-            println!("{metric}");
-        }
-        std::process::exit(0);
-    }
-
-    // load config from file
-    let config = if let Some(file) = matches.get_one::<String>("CONFIG") {
-        debug!("loading config: {file}");
-        match PingserverConfig::load(file) {
-            Ok(c) => c,
-            Err(error) => {
-                eprintln!("error loading config file: {file}\n{error}");
-                std::process::exit(1);
-            }
-        }
-    } else {
-        Default::default()
-    };
-
-    // initialize logging
-    let log = configure_logging(&config);
-
-    // initialize metrics
-    common::metrics::init();
-
-    // initialize storage
-    let storage = Noop::new();
-
-    // initialize parser
-    let protocol = PingProtocol::default();
-
-    // initialize process
-    let process_builder = ProcessBuilder::<PingProtocol, Request, Response, Noop>::new(
-        &config, log, protocol, storage,
-    )
-    .expect("failed to initialize process");
-
-    // spawn threads and wait
-    let process = process_builder.spawn();
-    process.wait();
+        .expect("failed to initialize process")
+        .spawn()
+        .wait()
+    },
 }

--- a/src/server/rds/src/main.rs
+++ b/src/server/rds/src/main.rs
@@ -15,117 +15,23 @@
 #[macro_use]
 extern crate logger;
 
-use backtrace::Backtrace;
-use clap::{Arg, Command};
 use config::RdsConfig;
-use metriken::*;
 use pelikan_rds::Rds;
 use server::PERCENTILES;
 
-/// The entry point into the running [Rds] instance. This function parses the
-/// command line options, loads the configuration, and launches the core
-/// threads.
-fn main() {
-    // custom panic hook to terminate whole process after unwinding
-    std::panic::set_hook(Box::new(|s| {
-        eprintln!("{s}");
-        eprintln!("{:?}", Backtrace::new());
-        std::process::exit(101);
-    }));
-
-    // parse command line options
-    let matches = Command::new(env!("CARGO_BIN_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .long_about(
-            "One of the unified cache backends implemented in Rust. It \
-            uses segment-based storage to cache key/val pairs. It speaks the \
-            redis ASCII protocol (RESP) and supports some ASCII redis \
-            commands.",
-        )
-        .arg(
-            Arg::new("stats")
-                .short('s')
-                .long("stats")
-                .help("List all metrics in stats")
-                .num_args(0)
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("CONFIG")
-                .help("Server configuration file")
-                .index(1),
-        )
-        .arg(
-            Arg::new("print-config")
-                .help("List all options in config")
-                .long("config")
-                .short('c')
-                .action(clap::ArgAction::SetTrue),
-        )
-        .get_matches();
-
-    // output stats descriptions and exit if the `stats` option was provided
-    if matches.get_flag("stats") {
-        println!("{:<31} {:<15} DESCRIPTION", "NAME", "TYPE");
-
-        let mut metrics = Vec::new();
-
-        for metric in &metriken::metrics() {
-            let any = match metric.as_any() {
-                Some(any) => any,
-                None => {
-                    continue;
-                }
-            };
-
-            if any.downcast_ref::<Counter>().is_some() {
-                metrics.push(format!("{:<31} counter", metric.name()));
-            } else if any.downcast_ref::<Gauge>().is_some() {
-                metrics.push(format!("{:<31} gauge", metric.name()));
-            } else if any.downcast_ref::<AtomicHistogram>().is_some()
-                || any.downcast_ref::<RwLockHistogram>().is_some()
-            {
-                for (label, _) in PERCENTILES {
-                    let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{name:<31} percentile"));
-                }
-            } else {
-                continue;
-            }
-        }
-
-        metrics.sort();
-        for metric in metrics {
-            println!("{metric}");
-        }
-        std::process::exit(0);
-    }
-
-    // load config from file
-    let config = if let Some(file) = matches.get_one::<String>("CONFIG") {
-        debug!("loading config: {file}");
-        match RdsConfig::load(file) {
-            Ok(c) => c,
-            Err(error) => {
-                eprintln!("error loading config file: {file}\n{error}");
-                std::process::exit(1);
-            }
-        }
-    } else {
-        Default::default()
-    };
-
-    if matches.get_flag("print-config") {
-        config.print();
-        std::process::exit(0);
-    }
-
-    // launch rds
-    match Rds::new(config) {
+common::pelikan_main! {
+    about: "One of the unified cache backends implemented in Rust. It \
+        uses segment-based storage to cache key/val pairs. It speaks the \
+        redis ASCII protocol (RESP) and supports some ASCII redis \
+        commands.",
+    config: RdsConfig,
+    percentiles: PERCENTILES,
+    print_config: true,
+    launch: |config| match Rds::new(config) {
         Ok(rds) => rds.wait(),
         Err(e) => {
             eprintln!("error launching rds: {e}");
             std::process::exit(1);
         }
-    }
+    },
 }

--- a/src/server/rds/src/main.rs
+++ b/src/server/rds/src/main.rs
@@ -26,7 +26,7 @@ common::pelikan_main! {
         commands.",
     config: RdsConfig,
     percentiles: PERCENTILES,
-    print_config: true,
+    print_config,
     launch: |config| match Rds::new(config) {
         Ok(rds) => rds.wait(),
         Err(e) => {

--- a/src/server/segcache/src/main.rs
+++ b/src/server/segcache/src/main.rs
@@ -26,7 +26,7 @@ common::pelikan_main! {
         commands.",
     config: SegcacheConfig,
     percentiles: PERCENTILES,
-    print_config: true,
+    print_config,
     launch: |config| match Segcache::new(config) {
         Ok(segcache) => segcache.wait(),
         Err(e) => {

--- a/src/server/segcache/src/main.rs
+++ b/src/server/segcache/src/main.rs
@@ -15,117 +15,23 @@
 #[macro_use]
 extern crate logger;
 
-use backtrace::Backtrace;
-use clap::{Arg, Command};
 use config::SegcacheConfig;
-use metriken::*;
 use pelikan_segcache::Segcache;
 use server::PERCENTILES;
 
-/// The entry point into the running Segcache instance. This function parses the
-/// command line options, loads the configuration, and launches the core
-/// threads.
-fn main() {
-    // custom panic hook to terminate whole process after unwinding
-    std::panic::set_hook(Box::new(|s| {
-        eprintln!("{s}");
-        eprintln!("{:?}", Backtrace::new());
-        std::process::exit(101);
-    }));
-
-    // parse command line options
-    let matches = Command::new(env!("CARGO_BIN_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .long_about(
-            "One of the unified cache backends implemented in Rust. It \
-            uses segment-based storage to cache key/val pairs. It speaks the \
-            memcached ASCII protocol and supports some ASCII memcached \
-            commands.",
-        )
-        .arg(
-            Arg::new("stats")
-                .short('s')
-                .long("stats")
-                .help("List all metrics in stats")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("CONFIG")
-                .help("Server configuration file")
-                .action(clap::ArgAction::Set)
-                .index(1),
-        )
-        .arg(
-            Arg::new("print-config")
-                .short('c')
-                .long("config")
-                .help("List all options in config")
-                .action(clap::ArgAction::SetTrue),
-        )
-        .get_matches();
-
-    // output stats descriptions and exit if the `stats` option was provided
-    if matches.get_flag("stats") {
-        println!("{:<31} {:<15} DESCRIPTION", "NAME", "TYPE");
-
-        let mut metrics = Vec::new();
-
-        for metric in &metriken::metrics() {
-            let any = match metric.as_any() {
-                Some(any) => any,
-                None => {
-                    continue;
-                }
-            };
-
-            if any.downcast_ref::<Counter>().is_some() {
-                metrics.push(format!("{:<31} counter", metric.name()));
-            } else if any.downcast_ref::<Gauge>().is_some() {
-                metrics.push(format!("{:<31} gauge", metric.name()));
-            } else if any.downcast_ref::<AtomicHistogram>().is_some()
-                || any.downcast_ref::<RwLockHistogram>().is_some()
-            {
-                for (label, _) in PERCENTILES {
-                    let name = format!("{}_{}", metric.name(), label);
-                    metrics.push(format!("{name:<31} percentile"));
-                }
-            } else {
-                continue;
-            }
-        }
-
-        metrics.sort();
-        for metric in metrics {
-            println!("{metric}");
-        }
-        std::process::exit(0);
-    }
-
-    // load config from file
-    let config = if let Some(file) = matches.get_one::<String>("CONFIG") {
-        debug!("loading config: {file}");
-        match SegcacheConfig::load(file) {
-            Ok(c) => c,
-            Err(error) => {
-                eprintln!("error loading config file: {file}\n{error}");
-                std::process::exit(1);
-            }
-        }
-    } else {
-        Default::default()
-    };
-
-    if matches.get_flag("print-config") {
-        config.print();
-        std::process::exit(0);
-    }
-
-    // launch segcache
-    match Segcache::new(config) {
+common::pelikan_main! {
+    about: "One of the unified cache backends implemented in Rust. It \
+        uses segment-based storage to cache key/val pairs. It speaks the \
+        memcached ASCII protocol and supports some ASCII memcached \
+        commands.",
+    config: SegcacheConfig,
+    percentiles: PERCENTILES,
+    print_config: true,
+    launch: |config| match Segcache::new(config) {
         Ok(segcache) => segcache.wait(),
         Err(e) => {
             eprintln!("error launching segcache: {e}");
             std::process::exit(1);
         }
-    }
+    },
 }


### PR DESCRIPTION
## Summary
- The four product entry points (pingserver, segcache, rds, pingproxy) carried 477 lines of near-identical boilerplate; each `main.rs` now declares only its product identity — about text, config type, percentile source, launch closure — against a shared `pelikan_main!` macro in `common` (net −235 lines).
- A macro rather than a generic fn keeps every deployed binary monomorphic and resolves expanded tokens against each product's own dependency set, so `common` gains no clap/metriken/logger edges.
- One deliberate behavior change: pingproxy had drifted from its siblings — config errors went to stdout without the `error loading config file:` prefix, and its panic hook logged via `error!` instead of stderr. The macro normalizes it to match the other three.
- `print_config` is a presence-only marker (review follow-up): include the bare token to add `-c`/`--config`, omit it otherwise; `print_config: false` no longer parses.

## Operational note (for release notes)
pingproxy panics now go to stderr, not the log file. This matches the other three products and avoids depending on the logger inside a panic handler, but deployments that capture logs without capturing stderr will no longer record pingproxy panic output — capture stderr, as the other products already require.

## Test plan
- [x] Golden-file comparison of `--help`, `--version`, `--stats`, `-c`, and bad-config handling across all four binaries before/after: byte-identical except the pingproxy normalization above (re-verified after the marker change)
- [x] Negative check: `print_config: false` fails to compile (`no rules expected ':'`)
- [x] `cargo test` for common + all four products (incl. segcache/rds integration harnesses): pass
- [x] `cargo fmt --all --check`: clean
- [x] `cargo clippy` for the touched crates: no new warnings (one pre-existing in pelikan-net, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)